### PR TITLE
Update fr.po

### DIFF
--- a/om_hr_payroll/i18n/fr.po
+++ b/om_hr_payroll/i18n/fr.po
@@ -59,7 +59,7 @@ msgid ""
 msgstr ""
 "<span colspan=\"4\" nolabel=\"1\">Cet assistant va générer les fiches de "
 "paie de(s) l'employé(s) sélectionné(s) sur base des dates et des notes de "
-"crédit figurant sur les bulletins de paie."
+"crédit figurant sur les bulletins de paie.</span>"
 
 #. module: hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip


### PR DESCRIPTION
The translation of "<span colspan=\"4\" nolabel=\"1\">This wizard will generate payslips for all"
" selected employee(s) based on the dates and credit note specified on "
"Payslips Run.</span>" causes makes the Generate Payslips button obsolete because it misses the closing of the span tag.