### PR TITLE
remove company field from hr_contract_form_inherit

### DIFF
--- a/om_hr_payroll/views/hr_contract_views.xml
+++ b/om_hr_payroll/views/hr_contract_views.xml
@@ -16,7 +16,6 @@
                 <field name="struct_id" required="1"/>
             </xpath>
             <xpath expr="//field[@name='job_id']" position="before">
-                <field name="company_id" groups="base.group_multi_company"/>
                 <field name="currency_id" invisible="1"/>
             </xpath>
              <xpath expr="//field[@name='resource_calendar_id']" position="after">


### PR DESCRIPTION
The company field shows twice in contract form view, It already exists in hr_contract_form view and it's added again to the hr_contract_form_inherit view so I removed it from hr_contract_form_inherit view.