### PR TITLE
[FIX] oms_account_accountant: remove duplicated key

### DIFF
--- a/om_account_accountant/__manifest__.py
+++ b/om_account_accountant/__manifest__.py
@@ -13,7 +13,6 @@
     'maintainer': 'Odoo Mates',
     'license': 'LGPL-3',
     'support': 'odoomates@gmail.com',
-    'website': '',
     'depends': ['accounting_pdf_reports', 'om_account_asset',
                 'om_account_budget', 'om_account_bank_statement_import'],
     'demo': [],


### PR DESCRIPTION
The `website` key was in the manifest twice before this fix.