### PR TITLE
[IMP] oms_account_accountant: remove unused import

### DIFF
--- a/om_account_accountant/models/account_settings.py
+++ b/om_account_accountant/models/account_settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 
 
 class ResConfigSettings(models.TransientModel):


### PR DESCRIPTION
Since nothing is translated in this inherit we don't need to import `_`