### PR TITLE
[IMP] om_account_accountant: remove unused import

### DIFF
--- a/om_account_accountant/models/account_fiscal_year.py
+++ b/om_account_accountant/models/account_fiscal_year.py
@@ -4,9 +4,6 @@ from odoo.exceptions import ValidationError
 from odoo import api, fields, models, _
 
 
-from datetime import datetime
-
-
 class AccountFiscalYear(models.Model):
     _name = 'account.fiscal.year'
     _description = 'Fiscal Year'


### PR DESCRIPTION
Since `datetime` is not used anywhere in this Python file we can remove it.