### PR TITLE
[FIX] om_account_budget: use for in self

### DIFF
--- a/om_account_budget/models/account_budget.py
+++ b/om_account_budget/models/account_budget.py
@@ -152,14 +152,14 @@ class CrossoveredBudgetLines(models.Model):
 
     
     def _compute_line_name(self):
-        #just in case someone opens the budget line in form view
-        computed_name = self.crossovered_budget_id.name
-        if self.general_budget_id:
-            computed_name += ' - ' + self.general_budget_id.name
-        if self.analytic_account_id:
-            computed_name += ' - ' + self.analytic_account_id.name
-        self.name = computed_name
-
+        for line in self:
+            computed_name = line.crossovered_budget_id.name
+            if line.general_budget_id:
+                computed_name += ' - ' + line.general_budget_id.name
+            if line.analytic_account_id:
+                computed_name += ' - ' + line.analytic_account_id.name
+            line.name = computed_name
+    
     
     def _compute_practical_amount(self):
         for line in self:


### PR DESCRIPTION
Error fixed: expected singleton, when the budget line is used as many2one field in another model, and a user tries to select one from the form.