### PR TITLE
[FIX] code value at get_worked_day_lines function

### DIFF
--- a/om_hr_payroll/models/hr_payslip.py
+++ b/om_hr_payroll/models/hr_payslip.py
@@ -200,7 +200,7 @@ class HrPayslip(models.Model):
                 current_leave_struct = leaves.setdefault(holiday.holiday_status_id, {
                     'name': holiday.holiday_status_id.name or _('Global Leaves'),
                     'sequence': 5,
-                    'code': holiday.holiday_status_id.name or 'GLOBAL',
+                    'code': holiday.holiday_status_id.code or 'GLOBAL',
                     'number_of_days': 0.0,
                     'number_of_hours': 0.0,
                     'contract_id': contract.id,


### PR DESCRIPTION
There are bugs (missing code) in `get_worked_day_lines` function.

That is making a problem while I tried to calculate a salary rule based on the number of Unpaid Leave. The existing is return the whole name in the `code` field and need to replace it with the correct code.

Thanks.