### PR TITLE
Squash "Same label" warning in Accounting PDF Reports

### DIFF
--- a/accounting_pdf_reports/wizards/account_report.py
+++ b/accounting_pdf_reports/wizards/account_report.py
@@ -20,8 +20,8 @@ class AccountingReport(models.TransientModel):
     account_report_id = fields.Many2one('account.financial.report', string='Account Reports', required=True, default=_get_account_report)
     label_filter = fields.Char(string='Column Label', help="This label will be displayed on report to show the balance computed for the given comparison filter.")
     filter_cmp = fields.Selection([('filter_no', 'No Filters'), ('filter_date', 'Date')], string='Filter by', required=True, default='filter_no')
-    date_from_cmp = fields.Date(string='Start Date')
-    date_to_cmp = fields.Date(string='End Date')
+    date_from_cmp = fields.Date(string='Start Date (Comparison)')
+    date_to_cmp = fields.Date(string='End Date (Comparison)')
     debit_credit = fields.Boolean(string='Display Debit/Credit Columns', help="This option allows you to get more details about the way your balances are computed. Because it is space consuming, we do not allow to use it while doing a comparison.")
 
     def _build_comparison_context(self, data):

--- a/accounting_pdf_reports/wizards/balance_sheet.xml
+++ b/accounting_pdf_reports/wizards/balance_sheet.xml
@@ -81,8 +81,8 @@
                             <field name="filter_cmp"/>
                         </group>
                         <group string="Dates" attrs="{'invisible':[('filter_cmp', '!=', 'filter_date')]}">
-                            <field name="date_from_cmp" attrs="{'required':[('filter_cmp', '=', 'filter_date')]}"/>
-                            <field name="date_to_cmp" attrs="{'required':[('filter_cmp', '=', 'filter_date')]}"/>
+                            <field name="date_from_cmp" string="Start Date" attrs="{'required':[('filter_cmp', '=', 'filter_date')]}"/>
+                            <field name="date_to_cmp" string="End Date" attrs="{'required':[('filter_cmp', '=', 'filter_date')]}"/>
                         </group>
                     </page>
                 </notebook>


### PR DESCRIPTION
This is a small change to get rid of the installation warning. 

```
2022-01-03 14:33:54,071 1 WARNING devel odoo.addons.base.models.ir_model: Two fields (date_from_cmp, date_from) of accounting.report() have the same label: Start Date. 
2022-01-03 14:33:54,071 1 WARNING devel odoo.addons.base.models.ir_model: Two fields (date_to_cmp, date_to) of accounting.report() have the same label: End Date.
```
I have restored the name of the fields in the xml. I don't see other places where those fields are used.