### PR TITLE
[FIX] om_account_asset: Fix Modify Depreciation wizard so final depreciation not deleted (Issue #57)

### DIFF
--- a/om_account_asset/wizard/asset_modify.py
+++ b/om_account_asset/wizard/asset_modify.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class AssetModify(models.TransientModel):
@@ -53,6 +54,9 @@ class AssetModify(models.TransientModel):
             'method_period': self.method_period,
             'method_end': self.method_end,
         }
+        if asset_vals['method_number'] <= asset.entry_count:
+            raise UserError(_('The number of depreciations must be greater than the number of posted or draft entries '
+                              'to allow for complete depreciation of the asset.'))
         asset.write(asset_vals)
         asset.compute_depreciation_board()
         tracked_fields = self.env['account.asset.asset'].fields_get(['method_number', 'method_period', 'method_end'])


### PR DESCRIPTION
Fix for Issue #57  Add check to ensure there is always at least 1 unposted depreciation line so that asset can be fully depreciated from books (currently the wizard will let you delete the final depreciation line, which means the asset will never be fully depreciated)