### PR TITLE
Add Partner Ledger to Partner Print, Ar Language enhancements

### DIFF
--- a/accounting_pdf_reports/i18n/ar.po
+++ b/accounting_pdf_reports/i18n/ar.po
@@ -167,7 +167,7 @@ msgstr "تقرير الحساب"
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__account_report_id
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_account_reports
 msgid "Account Reports"
-msgstr "تقارير الحسا"
+msgstr "تقارير الحساب"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance

--- a/accounting_pdf_reports/i18n/ar.po
+++ b/accounting_pdf_reports/i18n/ar.po
@@ -7,15 +7,15 @@ msgstr ""
 "Project-Id-Version: Odoo Server 14.0-20201019\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-12-11 14:51+0000\n"
-"PO-Revision-Date: 2020-12-11 10:54-0400\n"
+"PO-Revision-Date: 2022-05-21 13:26+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: es_DO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"Language: es_DO\n"
-"X-Generator: Poedit 2.4.1\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
@@ -167,7 +167,7 @@ msgstr "تقرير الحساب"
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__account_report_id
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_account_reports
 msgid "Account Reports"
-msgstr "تقارير الحساب
+msgstr "تقارير الحسا"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
@@ -483,11 +483,11 @@ msgid ""
 "accounts that are typically more credited than debited and that you would "
 "like to print as positive amounts in your reports; e.g.: Income account."
 msgstr ""
-"للحسابات التي يتم خصمها عادةً أكثر من الدائن وأنك "
-"ترغب في طباعتها كمبالغ سالبة في تقاريرك ، يجب عليك عكسها "
-"علامة التوازن على سبيل المثال: حساب المصاريف. الأمر نفسه ينطبق على "
-"الحسابات التي يتم إيداعها عادةً أكثر من الخصم والتي تريدها "
-"ترغب في طباعة مبالغ موجبة في تقاريرك ؛ على سبيل المثال: حساب الدخل "
+"للحسابات التي يتم خصمها عادةً أكثر من الدائن وأنك ترغب في طباعتها كمبالغ "
+"سالبة في تقاريرك ، يجب عليك عكسها علامة التوازن على سبيل المثال: حساب "
+"المصاريف. الأمر نفسه ينطبق على الحسابات التي يتم إيداعها عادةً أكثر من الخصم "
+"والتي تريدها ترغب في طباعة مبالغ موجبة في تقاريرك ؛ على سبيل المثال: حساب "
+"الدخل."
 
 #. module: accounting_pdf_reports
 #: code:addons/accounting_pdf_reports/report/report_aged_partner.py:0
@@ -552,8 +552,8 @@ msgid ""
 "If you selected date, this field allow you to add a row to display the "
 "amount of debit/credit/balance that precedes the filter you've set."
 msgstr ""
-"إذا قمت بتحديد التاريخ ، فإن هذا الحقل يسمح لك بإضافة صف لعرض ملف "
-"مبلغ الخصم / الائتمان / الرصيد الذي يسبق الفلتر الذي قمت بتعيينه "
+"إذا قمت بتحديد التاريخ ، فإن هذا الحقل يسمح لك بإضافة صف لعرض ملف مبلغ "
+"الخصم / الائتمان / الرصيد الذي يسبق الفلتر الذي قمت بتعيينه."
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__initial_balance
@@ -571,8 +571,7 @@ msgid ""
 "It adds the currency column on report if the currency differs from the "
 "company currency."
 msgstr ""
-"يقوم بإضافة عمود العملة في التقرير إذا كانت العملة تختلف عن "
-"عملة الشركة."
+"يقوم بإضافة عمود العملة في التقرير إذا كانت العملة تختلف عن عملة الشركة."
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__5
@@ -797,9 +796,7 @@ msgstr "Imprimir"
 msgid ""
 "Print Report with the currency column if the currency differs from the "
 "company currency."
-msgstr ""
-"اطبع التقرير بعمود العملة إذا كانت العملة تختلف عن "
-"عملة الشركة"
+msgstr "اطبع التقرير بعمود العملة إذا كانت العملة تختلف عن عملة الشركة."
 
 #. module: accounting_pdf_reports
 #: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_profitloss_toreport0
@@ -853,7 +850,7 @@ msgstr "تقرير اسم"
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.account_aged_balance_view
 msgid "Report Options"
-msgstr "Opciones del informe"
+msgstr "خيارات التقرير"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_search
@@ -957,8 +954,7 @@ msgid ""
 "This label will be displayed on report to show the balance computed for the "
 "given comparison filter."
 msgstr ""
-"سيتم عرض هذه التسمية في التقرير لإظهار الرصيد المحسوب لـ "
-"مرشح مقارنة معين."
+"سيتم عرض هذه التسمية في التقرير لإظهار الرصيد المحسوب لـ مرشح مقارنة معين."
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,help:accounting_pdf_reports.field_accounting_report__debit_credit
@@ -967,9 +963,8 @@ msgid ""
 "computed. Because it is space consuming, we do not allow to use it while "
 "doing a comparison."
 msgstr ""
-"يتيح لك هذا الخيار الحصول على مزيد من التفاصيل حول طريقة أرصدةك "
-"محسوب. نظرًا لأنها تستهلك مساحة ، فنحن لا نسمح باستخدامها أثناء "
-"إجراء مقارنة."
+"يتيح لك هذا الخيار الحصول على مزيد من التفاصيل حول طريقة أرصدةك محسوب. نظرًا "
+"لأنها تستهلك مساحة ، فنحن لا نسمح باستخدامها أثناء إجراء مقارنة."
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__2
@@ -1050,9 +1045,9 @@ msgid ""
 "leave the automatic formatting, it will be computed based on the financial "
 "reports hierarchy (auto-computed field 'level')."
 msgstr ""
-"يمكنك هنا إعداد التنسيق الذي تريده لعرض هذا السجل. اذا أنت "
-"اترك التنسيق التلقائي ، فسيتم حسابه بناءً على البيانات المالية "
-"التسلسل الهرمي للتقارير ("مستوى" الحقل المحسوب تلقائيًا). "
+"يمكنك هنا إعداد التنسيق الذي تريده لعرض هذا السجل. اذا أنت اترك التنسيق "
+"التلقائي ، فسيتم حسابه بناءً على البيانات المالية التسلسل الهرمي للتقارير "
+"(\"مستوى\" الحقل المحسوب تلقائيًا)."
 
 #. module: accounting_pdf_reports
 #: code:addons/accounting_pdf_reports/wizard/account_general_ledger.py:0

--- a/accounting_pdf_reports/i18n/ar_001.po
+++ b/accounting_pdf_reports/i18n/ar_001.po
@@ -7,13 +7,15 @@ msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-04-15 12:36+0000\n"
-"PO-Revision-Date: 2022-04-15 12:36+0000\n"
+"PO-Revision-Date: 2022-05-21 13:36+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
@@ -23,7 +25,7 @@ msgstr ":دفتر الأستاذ العام"
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
 msgid ": Trial Balance"
-msgstr ": ميزان المراجعة\n"
+msgstr ": ميزان المراجعة"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
@@ -152,27 +154,27 @@ msgstr "<strong>المجموع</strong>"
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
 msgid "Account"
-msgstr "الحساب\n"
+msgstr "الحساب"
 
 #. module: accounting_pdf_reports
 #: model:ir.model,name:accounting_pdf_reports.model_account_aged_trial_balance
 msgid "Account Aged Trial balance Report"
-msgstr "تقرير ميزان المراجعة المسن في الحساب\n"
+msgstr "تقرير ميزان المراجعة المسن في الحساب"
 
 #. module: accounting_pdf_reports
 #: model:ir.model,name:accounting_pdf_reports.model_account_common_account_report
 msgid "Account Common Account Report"
-msgstr "تقرير الحساب المشترك\n"
+msgstr "تقرير الحساب المشترك"
 
 #. module: accounting_pdf_reports
 #: model:ir.model,name:accounting_pdf_reports.model_account_common_partner_report
 msgid "Account Common Partner Report"
-msgstr "تقرير الشريك المشترك للحساب\n"
+msgstr "تقرير الشريك المشترك للحساب"
 
 #. module: accounting_pdf_reports
 #: model:ir.model,name:accounting_pdf_reports.model_account_report_partner_ledger
 msgid "Account Partner Ledger"
-msgstr "حساب شريك الأستاذ\n"
+msgstr "حساب شريك الأستاذ"
 
 #. module: accounting_pdf_reports
 #: model:ir.model,name:accounting_pdf_reports.model_account_print_journal
@@ -185,33 +187,33 @@ msgstr "طباعة دفتر اليومية"
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_search
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_tree
 msgid "Account Report"
-msgstr "تقرير الحساب\n"
+msgstr "تقرير الحساب"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__account_report_id
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_account_reports
 msgid "Account Reports"
-msgstr "تقارير الحساب\n"
+msgstr "تقارير الحساب"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
 msgid "Account Total"
-msgstr "إجمالي الحساب\n"
+msgstr "إجمالي الحساب"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__type__account_type
 msgid "Account Type"
-msgstr "نوع الحساب\n"
+msgstr "نوع الحساب"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__account_type_ids
 msgid "Account Types"
-msgstr "أنواع الحسابات\n"
+msgstr "أنواع الحسابات"
 
 #. module: accounting_pdf_reports
 #: model:ir.model,name:accounting_pdf_reports.model_accounting_report
 msgid "Accounting Report"
-msgstr "تقرير محاسبي\n"
+msgstr "تقرير محاسبي"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__account_ids
@@ -228,31 +230,31 @@ msgstr "الحسابات"
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_aged_trial_balance
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
 msgid "Aged Partner Balance"
-msgstr "رصيد الشريك المسن\n"
+msgstr "رصيد الشريك المسن"
 
 #. module: accounting_pdf_reports
 #: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_agedpartnerbalance
 msgid "Aged Partner Balance Report"
-msgstr "رصيد الشريك المسن\n"
+msgstr "رصيد الشريك المسن"
 
 #. module: accounting_pdf_reports
 #: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_aged_payable
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_aged_payable
 msgid "Aged Payable"
-msgstr "كبار السن مستحق الدفع\n"
+msgstr "كبار السن مستحق الدفع"
 
 #. module: accounting_pdf_reports
 #: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_aged_receivable
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_aged_receivable
 msgid "Aged Receivable"
-msgstr "مستحق قديم\n"
+msgstr "مستحق قديم"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_balance_report__display_account__all
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_account_report__display_account__all
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_general_ledger__display_account__all
 msgid "All"
-msgstr "الجميع\n"
+msgstr "الجميع"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
@@ -274,17 +276,17 @@ msgstr "كافة القيود"
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
 msgid "All Posted Entries"
-msgstr "كافة القيود المرحلّة "
+msgstr "كافة القيود المرحلّة"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
 msgid "All accounts"
-msgstr ""
+msgstr "جميع الحسابات"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
 msgid "All accounts'"
-msgstr ""
+msgstr "جميع الحسابات"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
@@ -297,7 +299,7 @@ msgstr "الحساب التحليلي"
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__analytic_account_ids
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__analytic_account_ids
 msgid "Analytic Accounts"
-msgstr "حسابات تحليلية\n"
+msgstr "حسابات تحليلية"
 
 #. module: accounting_pdf_reports
 #: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_assets0
@@ -307,7 +309,7 @@ msgstr "أصول"
 #. module: accounting_pdf_reports
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_finance_audit_reports
 msgid "Audit Reports"
-msgstr "تقارير التدقيق\n"
+msgstr "تقارير التدقيق"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__0
@@ -327,7 +329,7 @@ msgstr ""
 #: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_report_bs
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_account_report_bs
 msgid "Balance Sheet"
-msgstr "ورقة التوازن\n"
+msgstr "الميزانية العمومية"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
@@ -358,7 +360,7 @@ msgstr ""
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__label_filter
 msgid "Column Label"
-msgstr "تسمية العمود\n"
+msgstr "تسمية العمود"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__company_id
@@ -376,7 +378,7 @@ msgstr "الشركة"
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.accounting_report_view
 msgid "Comparison"
-msgstr "مقارنة\n"
+msgstr "مقارنة"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__create_uid
@@ -471,12 +473,12 @@ msgstr "المدين"
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__display_account
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__display_account
 msgid "Display Accounts"
-msgstr "عرض الحسابات\n"
+msgstr "عرض الحسابات"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__debit_credit
 msgid "Display Debit/Credit Columns"
-msgstr "عرض أعمدة الخصم / الائتمان\n"
+msgstr "عرض أعمدة الخصم / الائتمان"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__display_name
@@ -490,7 +492,7 @@ msgstr "عرض أعمدة الخصم / الائتمان\n"
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__display_name
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__display_name
 msgid "Display Name"
-msgstr "اسم العرض "
+msgstr "اسم العرض"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__display_detail__detail_flat
@@ -520,7 +522,7 @@ msgstr ""
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__enable_filter
 msgid "Enable Comparison"
-msgstr "تمكين المقارنة\n"
+msgstr "تمكين المقارنة"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__date_to
@@ -537,17 +539,17 @@ msgstr "تاريخ الانتهاء"
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.res_config_settings_view_form
 msgid "Enhanced Financial Reports"
-msgstr "التقارير المالية المحسنة\n"
+msgstr "التقارير المالية المحسنة"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__sort_selection
 msgid "Entries Sorted by"
-msgstr "القيود مصنفة حسب "
+msgstr "القيود مصنفة حسب"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
 msgid "Entry Label"
-msgstr "بطاقة الدخول\n"
+msgstr "بطاقة الدخول"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.res_config_settings_view_form
@@ -580,12 +582,12 @@ msgstr ""
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_finance_legal_statement
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_finance_reports_settings
 msgid "Financial Reports"
-msgstr "تقارير مالية\n"
+msgstr "تقارير مالية"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.res_config_settings_view_form
 msgid "Financial Reports in Excel"
-msgstr "التقارير المالية في Excel\n"
+msgstr "التقارير المالية في Excel"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,help:accounting_pdf_reports.field_account_financial_report__sign
@@ -620,7 +622,7 @@ msgstr "دفتر الأستاذ العام"
 #: model:ir.model,name:accounting_pdf_reports.model_account_report_general_ledger
 #: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_general_ledger
 msgid "General Ledger Report"
-msgstr "تقرير دفتر الأستاذ العام\n"
+msgstr "تقرير دفتر الأستاذ العام"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_search
@@ -651,7 +653,7 @@ msgstr ""
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__initial_balance
 msgid "Include Initial Balances"
-msgstr "قم بتضمين الأرصدة الأولية\n"
+msgstr "قم بتضمين الأرصدة الأولية"
 
 #. module: accounting_pdf_reports
 #: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_income0
@@ -663,7 +665,7 @@ msgstr ""
 msgid ""
 "It adds the currency column on report if the currency differs from the "
 "company currency."
-msgstr "يضيف عمود العملة في التقرير إذا كانت العملة تختلف عن عملة الشركة.\n"
+msgstr "يضيف عمود العملة في التقرير إذا كانت العملة تختلف عن عملة الشركة."
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__5
@@ -684,7 +686,7 @@ msgstr "يوميات"
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_general_ledger__sortby__sort_journal_partner
 msgid "Journal & Partner"
-msgstr "يوميات وشريك\n"
+msgstr "يوميات وشريك"
 
 #. module: accounting_pdf_reports
 #: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_journal
@@ -725,12 +727,12 @@ msgstr "دفاتر اليومية"
 #: model:ir.actions.report,name:accounting_pdf_reports.action_report_journal
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_print_journal
 msgid "Journals Audit"
-msgstr "تدقيق اليوميات\n"
+msgstr "تدقيق اليوميات"
 
 #. module: accounting_pdf_reports
 #: model:ir.actions.report,name:accounting_pdf_reports.action_report_journal_entries
 msgid "Journals Entries"
-msgstr "إدخالات المجلات\n"
+msgstr "إدخالات المجلات"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
@@ -856,12 +858,12 @@ msgstr "دفتر الأستاذ العام للشركاء"
 #. module: accounting_pdf_reports
 #: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_partnerledger
 msgid "Partner Ledger Report"
-msgstr "تقرير دفتر الأستاذ الشريك\n"
+msgstr "تقرير دفتر الأستاذ الشريك"
 
 #. module: accounting_pdf_reports
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_finance_partner_reports
 msgid "Partner Reports"
-msgstr "تقارير الشريك\n"
+msgstr "تقارير الشريك"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__result_selection
@@ -897,7 +899,7 @@ msgstr "الحسابات الدائنة"
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__period_length
 msgid "Period Length (days)"
-msgstr "طول الفترة (أيام)\n"
+msgstr "طول الفترة (أيام)"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__sign__1
@@ -907,7 +909,7 @@ msgstr ""
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.res_config_settings_view_form
 msgid "Preview financial reports without downloading"
-msgstr "معاينة التقارير المالية بدون تحميل\n"
+msgstr "معاينة التقارير المالية بدون تحميل"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.account_aged_balance_view
@@ -934,7 +936,7 @@ msgstr ""
 #: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_report_pl
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_account_report_pl
 msgid "Profit and Loss"
-msgstr "الربح والخسارة\n"
+msgstr "الربح والخسارة"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_aged_trial_balance__result_selection__customer
@@ -950,12 +952,12 @@ msgstr "الحسابات المدينة"
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_partner_ledger__result_selection__customer_supplier
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
 msgid "Receivable and Payable Accounts"
-msgstr "حسابات القبض والذمم الدائنة\n"
+msgstr "حسابات القبض والذمم الدائنة"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__reconciled
 msgid "Reconciled Entries"
-msgstr "القيوم المسوّاة "
+msgstr "القيود المسوّاة"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
@@ -1028,7 +1030,7 @@ msgstr ""
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__sortby
 msgid "Sort by"
-msgstr "ترتيب حسب\n"
+msgstr "ترتيب حسب"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__date_from
@@ -1040,7 +1042,7 @@ msgstr "ترتيب حسب\n"
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__date_from
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__date_from
 msgid "Start Date"
-msgstr "تاريخ البدء "
+msgstr "تاريخ البدء"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__target_move
@@ -1053,7 +1055,7 @@ msgstr "تاريخ البدء "
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__target_move
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__target_move
 msgid "Target Moves"
-msgstr "الحركات الهدف "
+msgstr "الحركات الهدف"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
@@ -1077,12 +1079,12 @@ msgstr ""
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_account_report
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
 msgid "Tax Report"
-msgstr "التقارير الضريبية\n"
+msgstr "التقارير الضريبية"
 
 #. module: accounting_pdf_reports
 #: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_tax_report
 msgid "Tax Reports"
-msgstr "التقارير الضريبية "
+msgstr "التقارير الضريبية"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,help:accounting_pdf_reports.field_accounting_report__label_filter
@@ -1090,8 +1092,7 @@ msgid ""
 "This label will be displayed on report to show the balance computed for the "
 "given comparison filter."
 msgstr ""
-"سيتم عرض هذه التسمية في التقرير لإظهار الرصيد المحسوب لمرشح المقارنة "
-"المحدد.\n"
+"سيتم عرض هذه التسمية في التقرير لإظهار الرصيد المحسوب لمرشح المقارنة المحدد."
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,help:accounting_pdf_reports.field_accounting_report__debit_credit
@@ -1101,7 +1102,7 @@ msgid ""
 "doing a comparison."
 msgstr ""
 "يتيح لك هذا الخيار الحصول على مزيد من التفاصيل حول طريقة حساب أرصدتك. نظرًا "
-"لأنها تستهلك مساحة ، فنحن لا نسمح باستخدامها أثناء إجراء مقارنة.\n"
+"لأنها تستهلك مساحة ، فنحن لا نسمح باستخدامها أثناء إجراء مقارنة."
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__2
@@ -1123,13 +1124,13 @@ msgstr ""
 #: model:ir.actions.report,name:accounting_pdf_reports.action_report_trial_balance
 #: model:ir.ui.menu,name:accounting_pdf_reports.menu_general_balance_report
 msgid "Trial Balance"
-msgstr "ميزان المراجعة\n"
+msgstr "ميزان المراجعة"
 
 #. module: accounting_pdf_reports
 #: model:ir.model,name:accounting_pdf_reports.model_account_balance_report
 #: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_trialbalance
 msgid "Trial Balance Report"
-msgstr "تقرير ميزان المراجعة\n"
+msgstr "تقرير ميزان المراجعة"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__type
@@ -1140,7 +1141,7 @@ msgstr ""
 #: code:addons/accounting_pdf_reports/report/report_aged_partner.py:0
 #, python-format
 msgid "Unknown Partner"
-msgstr "شريك غير معروف\n"
+msgstr "شريك غير معروف"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__type__sum
@@ -1158,7 +1159,7 @@ msgstr "مع العملة"
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_account_report__display_account__not_zero
 #: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_general_ledger__display_account__not_zero
 msgid "With balance is not equal to 0"
-msgstr "مع رصيد لا يساوي 0\n"
+msgstr "مع رصيد لا يساوي 0"
 
 #. module: accounting_pdf_reports
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
@@ -1173,7 +1174,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
 #: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
 msgid "With movements"
-msgstr "مع الحركات\n"
+msgstr "مع الحركات"
 
 #. module: accounting_pdf_reports
 #: model:ir.model.fields,help:accounting_pdf_reports.field_account_financial_report__style_overwrite
@@ -1187,16 +1188,16 @@ msgstr ""
 #: code:addons/accounting_pdf_reports/wizard/account_general_ledger.py:0
 #, python-format
 msgid "You must define a Start Date"
-msgstr "يجب عليك تحديد تاريخ البدء\n"
+msgstr "يجب عليك تحديد تاريخ البدء"
 
 #. module: accounting_pdf_reports
 #: code:addons/accounting_pdf_reports/wizard/aged_partner.py:0
 #, python-format
 msgid "You must set a period length greater than 0."
-msgstr "يجب عليك تعيين طول فترة أكبر من 0.\n"
+msgstr "يجب عليك تعيين طول فترة أكبر من 0."
 
 #. module: accounting_pdf_reports
 #: code:addons/accounting_pdf_reports/wizard/aged_partner.py:0
 #, python-format
 msgid "You must set a start date."
-msgstr "يجب عليك تحديد تاريخ البدء.\n"
+msgstr "يجب عليك تحديد تاريخ البدء."

--- a/accounting_pdf_reports/security/ir.model.access.csv
+++ b/accounting_pdf_reports/security/ir.model.access.csv
@@ -2,7 +2,7 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_account_financial_report_accountant,access.account.financial.report.manager,model_account_financial_report,account.group_account_user,1,1,1,1
 access_account_report_general_ledger,access.account.report.general.ledger,model_account_report_general_ledger,account.group_account_user,1,1,1,1
 access_account_balance_report,access.account.balance.report,model_account_balance_report,account.group_account_user,1,1,1,1
-access_account_report_partner_ledger,access.account.report.partner.ledger,model_account_report_partner_ledger,account.group_account_user,1,1,1,1
+access_account_report_partner_ledger,access.account.report.partner.ledger,model_account_report_partner_ledger,account.group_account_invoice,1,1,1,1
 access_accounting_report,access.accounting.report,model_accounting_report,account.group_account_user,1,1,1,1
 access_account_aged_trial_balance,access.account.aged.trial.balance,model_account_aged_trial_balance,account.group_account_user,1,1,1,1
 access_account_tax_report,access.account.tax.report.wizard,model_account_tax_report_wizard,account.group_account_user,1,1,1,1

--- a/accounting_pdf_reports/wizard/partner_ledger.xml
+++ b/accounting_pdf_reports/wizard/partner_ledger.xml
@@ -38,6 +38,26 @@
               sequence="5"
               parent="menu_finance_partner_reports"
               action="action_account_partner_ledger_menu"
-              groups="account.group_account_user,account.group_account_manager"/>
+              groups="account.group_account_invoice"/>
+
+     <!-- Add to Partner Print button -->
+     <record id="action_partner_report_partnerledger" model="ir.actions.act_window">
+        <field name="name">Balance Statement (Partner Ledger)</field>
+        <field name="print_report_name">"%s - Balance Statement (Partner Ledger)" % object.name</field>
+        <field name="res_model">account.report.partner.ledger</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="account_report_partner_ledger_view" />
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="base.model_res_partner" />
+        <field name="binding_type">report</field>
+        <field name="context">{
+            'default_partner_ids':active_ids,
+            'default_target_move': 'posted',
+            'default_result_selection': 'customer_supplier',
+            'default_reconciled': True,
+            'hide_partner':1,
+        }</field>
+        <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
+    </record>
 
 </odoo>


### PR DESCRIPTION
#### Add Partner Ledger Report to Partner
- Added report wizard to partner print button with group as billing `account.group_account_invoice`(ref #65).
- Needed to change group in security to be `account.group_account_invoice` since billing user should be able to print the report either way from Accounting or from partner itself.
- Changed `menueitem` group to be `account.group_account_invoice` since it is base for all other accounting groups.

#### Translation
- Escaped some quotes in translation (ref #69).
- Enhanced some translation for Arabic, will do another cycle later as well.
