### PR TITLE
[FIX] prevent asset creation if Invoice/Bill is refund.

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/om_account_asset/__manifest__.py
+++ b/om_account_asset/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Odoo 15 Assets Management',
-    'version': '15.0.6.8.0',
+    'version': '15.0.6.9.0',
     'author': 'Odoo Mates, Odoo SA',
     'depends': ['account'],
     'description': """Manage assets owned by a company or a person. 

--- a/om_account_asset/doc/RELEASE_NOTES.md
+++ b/om_account_asset/doc/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 ## Module <om_account_asset>
 
+#### 06.09.2022
+#### Version 15.0.6.9.0
+##### FIX
+- prevent asset creation if Invoice/Bill is refund.
+
 #### 29.04.2022
 #### Version 15.0.6.7.0
 ##### FIX

--- a/om_account_asset/models/account_move.py
+++ b/om_account_asset/models/account_move.py
@@ -10,7 +10,7 @@ class AccountMove(models.Model):
     _inherit = 'account.move'
 
     asset_ids = fields.One2many('account.asset.asset', 'invoice_id',
-                                string="Assets")
+                                string="Assets", copy=False)
 
     def button_draft(self):
         res = super(AccountMove, self).button_draft()
@@ -49,7 +49,7 @@ class AccountMove(models.Model):
         for inv in self:
             context = dict(self.env.context)
             context.pop('default_type', None)
-            for mv_line in inv.invoice_line_ids:
+            for mv_line in inv.invoice_line_ids.filtered(lambda line: line.move_id.move_type in ('in_invoice','out_invoice')):
                 mv_line.with_context(context).asset_create()
         return result
 


### PR DESCRIPTION
When you create credit note as partial refund and once you click on confirm button an asset created for that refund.