### PR TITLE
[Fix] Fix issues once generate the journal entries for depreciation lines

### DIFF
--- a/om_account_asset/__manifest__.py
+++ b/om_account_asset/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Odoo 16 Assets Management',
-    'version': '16.0.1.1.0',
+    'version': '16.0.1.2.0',
     'author': 'Odoo Mates, Odoo SA',
     'depends': ['account'],
     'description': """Manage assets owned by a company or a person. 

--- a/om_account_asset/models/account_asset.py
+++ b/om_account_asset/models/account_asset.py
@@ -589,11 +589,11 @@ class AccountAssetDepreciationLine(models.Model):
             'debit': 0.0 if float_compare(amount, 0.0, precision_digits=prec) > 0 else -amount,
             'credit': amount if float_compare(amount, 0.0, precision_digits=prec) > 0 else 0.0,
             'partner_id': line.asset_id.partner_id.id,
-            'analytic_account_id': account_analytic_id.id if category_id.type == 'sale' else False,
+            # 'analytic_account_id': account_analytic_id.id if category_id.type == 'sale' else False,
             # 'analytic_tag_ids': [(6, 0, analytic_tag_ids.ids)] if category_id.type == 'sale' else False,
             'analytic_distribution': analytic_distribution,
-            'currency_id': company_currency != current_currency and current_currency.id or False,
-            'amount_currency': company_currency != current_currency and - 1.0 * line.amount or 0.0,
+            'currency_id': company_currency != current_currency and current_currency.id or company_currency.id,
+            'amount_currency': - 1.0 * line.amount
         }
         move_line_2 = {
             'name': asset_name,
@@ -601,11 +601,11 @@ class AccountAssetDepreciationLine(models.Model):
             'credit': 0.0 if float_compare(amount, 0.0, precision_digits=prec) > 0 else -amount,
             'debit': amount if float_compare(amount, 0.0, precision_digits=prec) > 0 else 0.0,
             'partner_id': line.asset_id.partner_id.id,
-            'analytic_account_id': account_analytic_id.id if category_id.type == 'purchase' else False,
+            # 'analytic_account_id': account_analytic_id.id if category_id.type == 'purchase' else False,
             # 'analytic_tag_ids': [(6, 0, analytic_tag_ids.ids)] if category_id.type == 'purchase' else False,
             'analytic_distribution': analytic_distribution,
-            'currency_id': company_currency != current_currency and current_currency.id or False,
-            'amount_currency': company_currency != current_currency and line.amount or 0.0,
+            'currency_id': company_currency != current_currency and current_currency.id or company_currency.id,
+            'amount_currency': line.amount,
         }
         move_vals = {
             'ref': line.asset_id.code,


### PR DESCRIPTION
Fix the below issues once generate the journal entries for asset depreciation lines:

- Remove analytic account from created move line because it's removed from account move lines in Odoo 16.0.
-  Solve issue in created move line currency.
- The created journal entries created with zero values.