### PR TITLE
[16.0] Fixed bank statement import thingy

### DIFF
--- a/om_account_bank_statement_import/models/account_bank_statement_import.py
+++ b/om_account_bank_statement_import/models/account_bank_statement_import.py
@@ -90,7 +90,8 @@ class AccountBankStatementImport(models.TransientModel):
                                         'ref': field[2],
                                         'partner_id': self.get_partner(field[3]),
                                         'amount': field[4],
-                                        'currency_id':  self.get_currency(field[5])
+                                        'currency_id':  self.get_currency(field[5]),
+                                        'journal_id': self.env.context.get('active_id')
                                     })
                                     vals_list.append((0, 0, values))
                         statement_vals = {
@@ -126,7 +127,8 @@ class AccountBankStatementImport(models.TransientModel):
                                     'ref': line[2],
                                     'partner_id': self.get_partner(line[3]),
                                     'amount': line[4],
-                                    'currency_id': self.get_currency(line[5])
+                                    'currency_id': self.get_currency(line[5]),
+                                    'journal_id': self.env.context.get('active_id')
                                 })
                                 vals_list.append((0, 0, values))
                         statement_vals = {


### PR DESCRIPTION
In the past, I attempted to import a sample file but it failed. After adding multiple print statements throughout the code, I discovered that the problem was resolved by including a `journal_id` for every line in the `import_file` function. I have not yet tried using an .xlsx file, but I did test using a .csv file.