### PR TITLE
[FIX] accounting_pdf_reports: traceback on journal entry print

### DIFF
--- a/accounting_pdf_reports/__manifest__.py
+++ b/accounting_pdf_reports/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Odoo 16 Accounting Financial Reports',
-    'version': '16.0.2.0.2',
+    'version': '16.0.2.0.3',
     'category': 'Invoicing Management',
     'description': 'Accounting Reports For Odoo 16, Accounting Financial Reports, '
                    'Odoo 16 Financial Reports',

--- a/accounting_pdf_reports/report/report_journal_entries.xml
+++ b/accounting_pdf_reports/report/report_journal_entries.xml
@@ -68,7 +68,11 @@
                                                 <span t-field="line.name"/>
                                             </td>
                                             <td>
-                                                <span t-field="line.analytic_account_id.display_name"/>
+                                                <span>
+                                                    <div t-foreach="line.analytic_distribution" t-as="distribution">
+                                                        <t t-esc="line.env['account.analytic.account'].browse(int(distribution))[0].name"/>: <t t-esc="line.analytic_distribution.get(distribution)"/>
+                                                    </div>
+                                                </span>
                                             </td>
                                             <td class="text-end">
                                                 <span t-field="line.debit"


### PR DESCRIPTION
before this commit, on printing the journal entry
exception was shown to user.

after this commit, no exception on printing the journal entry report.