### PR TITLE
[I18N] Update translation terms in es_CR

### DIFF
--- a/accounting_pdf_reports/i18n/es_CR.po
+++ b/accounting_pdf_reports/i18n/es_CR.po
@@ -1,0 +1,1452 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* accounting_pdf_reports
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 20:48+0000\n"
+"PO-Revision-Date: 2023-07-08 14:49-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+msgid ": General ledger"
+msgstr ": Libro Mayor"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid ": Trial Balance"
+msgstr ": Balanza de comprobación"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+msgid "<span>Not due</span>"
+msgstr "<span>No Adeudado</span>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "<strong>Analytic Accounts:</strong>"
+msgstr "<strong>Cuentas analíticas:</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+msgid "<strong>Company:</strong>"
+msgstr "<strong>Compañía:</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_financial
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "<strong>Date from :</strong>"
+msgstr "<strong>Desde la fecha :</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_financial
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "<strong>Date to :</strong>"
+msgstr "<strong>Hasta la fecha :</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "<strong>Display Account:</strong>"
+msgstr "<strong>Mostrar Cuenta:</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+msgid "<strong>Display Account</strong>"
+msgstr "<strong>Mostrar Cuenta</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+msgid "<strong>Entries Sorted By:</strong>"
+msgstr "<strong>Apuntes ordenados por:</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+msgid "<strong>Journal:</strong>"
+msgstr "<strong>Diario:</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "<strong>Journals:</strong>"
+msgstr "<strong>Diarios:</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+msgid "<strong>Partner's:</strong>"
+msgstr "<strong>Del Socio:</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+msgid "<strong>Period Length (days)</strong>"
+msgstr "<strong>Duración del Período (días)</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+msgid "<strong>Purchase</strong>"
+msgstr "<strong>Compra</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+msgid "<strong>Sorted By:</strong>"
+msgstr "<strong>Ordenado Por:</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+msgid "<strong>Start Date:</strong>"
+msgstr "<strong>Fecha de Inicio:</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_financial
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "<strong>Target Moves:</strong>"
+msgstr "<strong>Movimientos señalados:</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#, fuzzy
+msgid "<strong>Total</strong>"
+msgstr "<strong>Total</strong>"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "Account"
+msgstr "Cuenta"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_account_type
+#, fuzzy
+msgid "Account Account Type"
+msgstr "Tipo de Cuenta"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_aged_trial_balance
+msgid "Account Aged Trial balance Report"
+msgstr "Contabilidad. Informe de Saldo Balance de Comprobación"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_common_account_report
+msgid "Account Common Account Report"
+msgstr "Contabilidad. Informe de Cuenta Común"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_common_partner_report
+msgid "Account Common Partner Report"
+msgstr "Contabilidad. Informe de socio Común"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_common_report
+#, fuzzy
+msgid "Account Common Report"
+msgstr "Contabilidad. Informe común"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_report_partner_ledger
+msgid "Account Partner Ledger"
+msgstr "Contabilidad. Libro Mayor de Socios"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_print_journal
+msgid "Account Print Journal"
+msgstr "Contabilidad. Imprimir diario"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_financial_report
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_form
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_search
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_tree
+msgid "Account Report"
+msgstr "Reporte de Cuenta"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__account_report_id
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_account_reports
+msgid "Account Reports"
+msgstr "Reportes de Cuenta"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+msgid "Account Total"
+msgstr "Cuenta Total"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__type__account_type
+msgid "Account Type"
+msgstr "Tipo de Cuenta"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__account_type_ids
+#, fuzzy
+msgid "Account Types"
+msgstr "Tipos de cuentas"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_accounting_report
+msgid "Accounting Report"
+msgstr "Reporte de Contabilidad"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__account_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__account_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__account_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__account_ids
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__type__accounts
+msgid "Accounts"
+msgstr "Cuentas"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_aged_balance_view
+#: model:ir.actions.report,name:accounting_pdf_reports.action_report_aged_partner_balance
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_aged_trial_balance
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+msgid "Aged Partner Balance"
+msgstr "Saldos vencidos de empresa"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_agedpartnerbalance
+msgid "Aged Partner Balance Report"
+msgstr "Informe de saldos vencidos de empresa"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_aged_payable
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_aged_payable
+msgid "Aged Payable"
+msgstr "Cuentas por pagar vencidas"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_aged_receivable
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_aged_receivable
+msgid "Aged Receivable"
+msgstr "Cuentas por cobrar vencidas"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_balance_report__display_account__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_account_report__display_account__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_general_ledger__display_account__all
+msgid "All"
+msgstr "Todos"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_aged_trial_balance__target_move__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_balance_report__target_move__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_account_report__target_move__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_journal_report__target_move__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_partner_report__target_move__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_report__target_move__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_print_journal__target_move__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_general_ledger__target_move__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_partner_ledger__target_move__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_tax_report_wizard__target_move__all
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__accounting_report__target_move__all
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_financial
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "All Entries"
+msgstr "Todos los asientos"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_aged_trial_balance__target_move__posted
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_balance_report__target_move__posted
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_account_report__target_move__posted
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_journal_report__target_move__posted
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_partner_report__target_move__posted
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_report__target_move__posted
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_print_journal__target_move__posted
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_general_ledger__target_move__posted
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_partner_ledger__target_move__posted
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_tax_report_wizard__target_move__posted
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__accounting_report__target_move__posted
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_financial
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "All Posted Entries"
+msgstr "Todos los asientos validados"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "All accounts"
+msgstr "Todas las cuentas"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+msgid "All accounts'"
+msgstr "Todas las cuentas'"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+msgid "Analytic Account"
+msgstr "Cuenta analitica"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__analytic_account_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__analytic_account_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__analytic_account_ids
+msgid "Analytic Accounts"
+msgstr "Cuentas analiticas"
+
+#. module: accounting_pdf_reports
+#: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_assets0
+msgid "Assets"
+msgstr "Activos"
+
+#. module: accounting_pdf_reports
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_finance_audit_reports
+msgid "Audit Reports"
+msgstr "Informes de auditoría"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__0
+msgid "Automatic formatting"
+msgstr "Formateo automático"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_financial
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "Balance"
+msgstr "Saldo Pendiente"
+
+#. module: accounting_pdf_reports
+#: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_balancesheet0
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_report_bs
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_account_report_bs
+msgid "Balance Sheet"
+msgstr "Hoja de Balance"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_partner_report_partnerledger
+#, fuzzy
+msgid "Balance Statement (Partner Ledger)"
+msgstr "Estado de cuenta (Partner Ledger)"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_liquidity
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__asset_cash
+#, fuzzy
+msgid "Bank and Cash"
+msgstr "Banco y efectivo"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+msgid "Base Amount"
+msgstr "Importe base"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.account_aged_balance_view
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.account_common_report_view
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.accounting_tax_report_view
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__children_ids
+msgid "Children"
+msgstr "Hijo"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_form
+msgid "Childrens"
+msgstr "Hijos"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "Code"
+msgstr "Código"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__label_filter
+msgid "Column Label"
+msgstr "Etiqueta de Columna"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_common_journal_report
+#, fuzzy
+msgid "Common Journal Report"
+msgstr "Informe de diario común"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__company_id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__company_id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__company_id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__company_id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__company_id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__company_id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__company_id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__company_id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__company_id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__company_id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__company_id
+msgid "Company"
+msgstr "Compañía"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.accounting_report_view
+msgid "Comparison"
+msgstr "Comparación"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_direct_costs
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__expense_direct_cost
+#, fuzzy
+msgid "Cost of Revenue"
+msgstr "Costo de ingresos"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_account_type__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__create_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_account_type__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__create_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_financial
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "Credit"
+msgstr "Haber"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_credit_card
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__liability_credit_card
+#, fuzzy
+msgid "Credit Card"
+msgstr "Tarjeta de Crédito"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_current_assets
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__asset_current
+#, fuzzy
+msgid "Current Assets"
+msgstr "Activos Corrientes"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_current_liabilities
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__liability_current
+#, fuzzy
+msgid "Current Liabilities"
+msgstr "Pasivos Corrientes"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_unaffected_earnings
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__equity_unaffected
+#, fuzzy
+msgid "Current Year Earnings"
+msgstr "Ganancias del año actual"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_print_journal__sort_selection__date
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_general_ledger__sortby__sort_date
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__accounting_report__filter_cmp__filter_date
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+msgid "Date"
+msgstr "Fecha"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__date_from
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__date_from_cmp
+msgid "Date From"
+msgstr "Fecha desde"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__date_to
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__date_to_cmp
+msgid "Date To"
+msgstr "Fecha hasta"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+msgid "Date:"
+msgstr "Fecha:"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.accounting_report_view
+msgid "Dates"
+msgstr "Fechas"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_financial
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "Debit"
+msgstr "Debe"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_depreciation
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__expense_depreciation
+#, fuzzy
+msgid "Depreciation"
+msgstr "Depreciación"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__display_account
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__display_account
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__display_account
+msgid "Display Accounts"
+msgstr "Mostrar Cuentas"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__debit_credit
+msgid "Display Debit/Credit Columns"
+msgstr "Mostrar Columnas de Debe/Haber"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_account_type__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__display_name
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__display_detail__detail_flat
+msgid "Display children flat"
+msgstr "Mostrar Cuentas"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__display_detail__detail_with_hierarchy
+msgid "Display children with hierarchy"
+msgstr "Mostrar Cuentas"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__display_detail
+msgid "Display details"
+msgstr "Mostrar detalles"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.res_config_settings_view_form
+#, fuzzy
+msgid "Drill Down Reports"
+msgstr "Informes Detallados"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.res_config_settings_view_form
+msgid "Dynamic Accounting Reports"
+msgstr "Reportes de contabilidad dinámicos"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__enable_filter
+msgid "Enable Comparison"
+msgstr "Habilitar Comparación"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__date_to
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__date_to
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__date_to
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__date_to
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__date_to
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__date_to
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__date_to
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__date_to
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__date_to
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__date_to
+msgid "End Date"
+msgstr "Fecha final"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.res_config_settings_view_form
+#, fuzzy
+msgid "Enhanced Financial Reports"
+msgstr "Informes Financieros Mejorados"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__sort_selection
+msgid "Entries Sorted by"
+msgstr "Asientos ordenadas por"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+msgid "Entry Label"
+msgstr "Nivel Básico"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_equity
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__equity
+#, fuzzy
+msgid "Equity"
+msgstr "Capital"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.res_config_settings_view_form
+msgid "Excel Reports"
+msgstr "Reportes en Excel"
+
+#. module: accounting_pdf_reports
+#: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_expense0
+msgid "Expense"
+msgstr "Gasto"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_expenses
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__expense
+#, fuzzy
+msgid "Expenses"
+msgstr "Gastos"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__filter_cmp
+msgid "Filter by"
+msgstr "Filtrar por"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.report,name:accounting_pdf_reports.action_report_financial
+msgid "Financial Report"
+msgstr "Reporte financiero"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__style_overwrite
+msgid "Financial Report Style"
+msgstr "Estilo de Reporte Financiero"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_financial_report_tree
+#: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_financial
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_finance_legal_statement
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_finance_reports_settings
+msgid "Financial Reports"
+msgstr "Reportes Financieros"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.res_config_settings_view_form
+#, fuzzy
+msgid "Financial Reports in Excel"
+msgstr "Reportes Financieros en Excel"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_fixed_assets
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__asset_fixed
+#, fuzzy
+msgid "Fixed Assets"
+msgstr "Activos Fijos"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,help:accounting_pdf_reports.field_account_financial_report__sign
+msgid ""
+"For accounts that are typically more debited than credited and that you "
+"would like to print as negative amounts in your reports, you should reverse "
+"the sign of the balance; e.g.: Expense account. The same applies for "
+"accounts that are typically more credited than debited and that you would "
+"like to print as positive amounts in your reports; e.g.: Income account."
+msgstr ""
+"En el caso de las cuentas que suelen estar más cargadas que acreditadas y "
+"que le gustaría imprimir como cantidades negativas en sus informes, debe "
+"invertir el signo del saldo; ej .: cuenta de gastos. Lo mismo se aplica a "
+"las cuentas que suelen estar más acreditadas que debitadas y que le "
+"gustaría imprimir como cantidades positivas en sus informes; ej .: cuenta "
+"de ingresos."
+
+#. module: accounting_pdf_reports
+#. odoo-python
+#: code:addons/accounting_pdf_reports/report/report_aged_partner.py:0
+#: code:addons/accounting_pdf_reports/report/report_financial.py:0
+#: code:addons/accounting_pdf_reports/report/report_general_ledger.py:0
+#: code:addons/accounting_pdf_reports/report/report_journal.py:0
+#: code:addons/accounting_pdf_reports/report/report_partner_ledger.py:0
+#: code:addons/accounting_pdf_reports/report/report_tax.py:0
+#: code:addons/accounting_pdf_reports/report/report_trial_balance.py:0
+#, python-format
+msgid "Form content is missing, this report cannot be printed."
+msgstr "Falta el contenido del formulario, este informe no se puede imprimir."
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_general_ledger_menu
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_moves_ledger_general
+#: model:ir.actions.report,name:accounting_pdf_reports.action_report_general_ledger
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_action_account_moves_ledger_general
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_general_ledger
+msgid "General Ledger"
+msgstr "Libro mayor"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_report_general_ledger
+#: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_general_ledger
+msgid "General Ledger Report"
+msgstr "Reporte de Libro Mayor"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_search
+msgid "Group By"
+msgstr "Agrupar por"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_account_type__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__id
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__id
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,help:accounting_pdf_reports.field_account_report_general_ledger__initial_balance
+msgid ""
+"If you selected date, this field allow you to add a row to display the "
+"amount of debit/credit/balance that precedes the filter you've set."
+msgstr ""
+"Si seleccionó la fecha, este campo le permite agregar una fila para mostrar "
+"la cantidad de débito / crédito / saldo que precede al filtro que "
+"estableció."
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__initial_balance
+msgid "Include Initial Balances"
+msgstr "Incluir Saldos Iniciales"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_revenue
+#: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_income0
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__income
+msgid "Income"
+msgstr "Ingreso"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,help:accounting_pdf_reports.field_account_report_partner_ledger__amount_currency
+msgid ""
+"It adds the currency column on report if the currency differs from the "
+"company currency."
+msgstr ""
+"Agrega la columna de moneda en el informe si la moneda difiere de la moneda "
+"de la empresa."
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__5
+msgid "Italic Text (smaller)"
+msgstr "Texto en cursiva (más pequeño)"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#, fuzzy
+msgid "JRNL"
+msgstr "DIARIO"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+msgid "Journal"
+msgstr "Diario"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_general_ledger__sortby__sort_journal_partner
+msgid "Journal & Partner"
+msgstr "Diario & Socio"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_journal
+msgid "Journal Audit Report"
+msgstr "Reporte del diario de auditoría"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_print_journal__sort_selection__move_name
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+msgid "Journal Entry Number"
+msgstr "Número de asiento"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_move_line
+msgid "Journal Item"
+msgstr "Apunte contable"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+msgid "Journal and Partner"
+msgstr "Diario y Socio"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+msgid "Journal:"
+msgstr "Diario:"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__journal_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__journal_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__journal_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__journal_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__journal_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__journal_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__journal_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__journal_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__journal_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__journal_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__journal_ids
+msgid "Journals"
+msgstr "Diarios"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_print_journal_menu
+#: model:ir.actions.report,name:accounting_pdf_reports.action_report_journal
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_print_journal
+msgid "Journals Audit"
+msgstr "Auditoría de Libros"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.report,name:accounting_pdf_reports.action_report_journal_entries
+msgid "Journals Entries"
+msgstr "Entradas de diarios"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+msgid "Label"
+msgstr "Descripción"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_account_type____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard____last_update
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report____last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_account_type__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__write_uid
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__write_uid
+msgid "Last Updated by"
+msgstr "Última actualización de"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_account_type__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__write_date
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: accounting_pdf_reports
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_finance_entries_accounting_ledgers
+#, fuzzy
+msgid "Ledgers"
+msgstr "Libros mayores"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__level
+msgid "Level"
+msgstr "Nivel"
+
+#. module: accounting_pdf_reports
+#: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_liability0
+#: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_liabilitysum0
+msgid "Liability"
+msgstr "Pasivo"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__1
+msgid "Main Title 1 (bold, underlined)"
+msgstr "Título principal 1 (negrita, subrayado)"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+msgid "Move"
+msgstr "Asiento"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_account_type__name
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_financial
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+msgid "Name"
+msgstr "Nombre"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+msgid "Net"
+msgstr "Neto"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__accounting_report__filter_cmp__filter_no
+msgid "No Filters"
+msgstr "Sin Filtros"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__display_detail__no_detail
+msgid "No detail"
+msgstr "Sin detalle"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_non_current_assets
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__asset_non_current
+#, fuzzy
+msgid "Non-current Assets"
+msgstr "Activos No Corrientes"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_non_current_liabilities
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__liability_non_current
+#, fuzzy
+msgid "Non-current Liabilities"
+msgstr "Pasivos No Corrientes"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__4
+msgid "Normal Text"
+msgstr "Texto Normal"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_off_sheet
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__off_balance
+#, fuzzy
+msgid "Off-Balance Sheet"
+msgstr "Hoja fuera de balance"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_other_income
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__income_other
+#, fuzzy
+msgid "Other Income"
+msgstr "Otro Ingreso"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__parent_id
+msgid "Parent"
+msgstr "Principal"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_search
+msgid "Parent Report"
+msgstr "Reporte Padre"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_moves_ledger_partner
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_partner_ledger_menu
+#: model:ir.actions.report,name:accounting_pdf_reports.action_report_partnerledger
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_action_account_moves_ledger_partner
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_partner_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+msgid "Partner Ledger"
+msgstr "Libro mayor de empresa"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_partnerledger
+msgid "Partner Ledger Report"
+msgstr "Reporte del libro mayor de empresa"
+
+#. module: accounting_pdf_reports
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_finance_partner_reports
+msgid "Partner Reports"
+msgstr "Reporte de empresas"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__result_selection
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__result_selection
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__result_selection
+msgid "Partner's"
+msgstr "De los Socios"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+msgid "Partner:"
+msgstr "Empresa:"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__partner_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__partner_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__partner_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__partner_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__partner_ids
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__partner_ids
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+msgid "Partners"
+msgstr "Contactos"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_payable
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__liability_payable
+#, fuzzy
+msgid "Payable"
+msgstr "Por pagar"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_aged_trial_balance__result_selection__supplier
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_partner_report__result_selection__supplier
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_partner_ledger__result_selection__supplier
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+msgid "Payable Accounts"
+msgstr "Cuentas a pagar"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__period_length
+msgid "Period Length (days)"
+msgstr "Duración del Período (días)"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_prepayments
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__asset_prepayments
+#, fuzzy
+msgid "Prepayments"
+msgstr "Pre-pagos"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__sign__1
+msgid "Preserve balance sign"
+msgstr "Conservar firma de balance"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.res_config_settings_view_form
+#, fuzzy
+msgid "Preview financial reports without downloading"
+msgstr "Obtenga una vista previa de los informes financieros sin descargar"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.account_aged_balance_view
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.account_common_report_view
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.accounting_tax_report_view
+msgid "Print"
+msgstr "Imprimir"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,help:accounting_pdf_reports.field_account_common_journal_report__amount_currency
+#: model:ir.model.fields,help:accounting_pdf_reports.field_account_print_journal__amount_currency
+msgid ""
+"Print Report with the currency column if the currency differs from the "
+"company currency."
+msgstr ""
+"Imprimir informe con columna moneda si la moneda difiere de la de la "
+"compañía."
+
+#. module: accounting_pdf_reports
+#: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_profitloss_toreport0
+msgid "Profit (Loss) to report"
+msgstr "Beneficio (pérdida) para informar"
+
+#. module: accounting_pdf_reports
+#: model:account.financial.report,name:accounting_pdf_reports.account_financial_report_profitandloss0
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_report_pl
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_account_report_pl
+msgid "Profit and Loss"
+msgstr "Ganancia y Perdida"
+
+#. module: accounting_pdf_reports
+#: model:account.account.type,name:accounting_pdf_reports.data_account_type_receivable
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_account_type__type__asset_receivable
+#, fuzzy
+msgid "Receivable"
+msgstr "Por cobrar"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_aged_trial_balance__result_selection__customer
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_partner_report__result_selection__customer
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_partner_ledger__result_selection__customer
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+msgid "Receivable Accounts"
+msgstr "Cuentas a cobrar"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_aged_trial_balance__result_selection__customer_supplier
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_partner_report__result_selection__customer_supplier
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_partner_ledger__result_selection__customer_supplier
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+msgid "Receivable and Payable Accounts"
+msgstr "Cuentas por Cobrar y Por Pagar"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__reconciled
+msgid "Reconciled Entries"
+msgstr "Asientos conciliados"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_partnerledger
+#, fuzzy
+msgid "Ref"
+msgstr "Ref"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal_entries
+msgid "Reference:"
+msgstr "Referencia:"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_form
+msgid "Report"
+msgstr "Informe"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__report_domain
+#, fuzzy
+msgid "Report Domain"
+msgstr "Dominio de Reporte"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__name
+msgid "Report Name"
+msgstr "Nombre de Informe"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.account_aged_balance_view
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.account_common_report_view
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.accounting_tax_report_view
+msgid "Report Options"
+msgstr "Opciones del informe"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_search
+msgid "Report Type"
+msgstr "Tipo de informe"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__account_report_id
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__type__account_report
+msgid "Report Value"
+msgstr "Valor del Informe"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.view_account_financial_report_search
+msgid "Reports"
+msgstr "Reportes"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__sign__-1
+msgid "Reverse balance sign"
+msgstr "Reversar firma de balance"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+msgid "Sale"
+msgstr "Venta"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__sign
+msgid "Sign on Reports"
+msgstr "Firma en Informes"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__6
+msgid "Smallest Text"
+msgstr "Texto más pequeño"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__sortby
+msgid "Sort by"
+msgstr "Ordenar por"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__date_from
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__date_from
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__date_from
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__date_from
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__date_from
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__date_from
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__date_from
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__date_from
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__date_from
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__date_from
+msgid "Start Date"
+msgstr "Fecha de inicio"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_aged_trial_balance__target_move
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_balance_report__target_move
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_account_report__target_move
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__target_move
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_partner_report__target_move
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_report__target_move
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__target_move
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_general_ledger__target_move
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__target_move
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_tax_report_wizard__target_move
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_accounting_report__target_move
+msgid "Target Moves"
+msgstr "Movimientos destino"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+msgid "Tax"
+msgstr "Impuesto"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+msgid "Tax Amount"
+msgstr "Importe impuesto"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_journal
+msgid "Tax Declaration"
+msgstr "Declaración de impuestos"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.report,name:accounting_pdf_reports.action_report_account_tax
+#: model:ir.model,name:accounting_pdf_reports.model_account_tax_report_wizard
+#: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_tax
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_account_report
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_tax
+msgid "Tax Report"
+msgstr "Reporte Impuestos"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_tax_report
+msgid "Tax Reports"
+msgstr "Informes de Impuestos"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,help:accounting_pdf_reports.field_account_account_type__type
+#, fuzzy
+msgid ""
+"These types are defined according to your country. The type contains more "
+"information about the account and its specificities."
+msgstr ""
+"Estos tipos se definen en función de tu país. Contienen más información "
+"sobre la cuenta y sus especificaciones."
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,help:accounting_pdf_reports.field_accounting_report__label_filter
+msgid ""
+"This label will be displayed on report to show the balance computed for the "
+"given comparison filter."
+msgstr ""
+"Esta etiqueta se mostrará en el informe para mostrar el saldo calculado "
+"para el filtro de comparación dado."
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,help:accounting_pdf_reports.field_accounting_report__debit_credit
+msgid ""
+"This option allows you to get more details about the way your balances are "
+"computed. Because it is space consuming, we do not allow to use it while "
+"doing a comparison."
+msgstr ""
+"Esta opción le permite obtener más detalles sobre la forma en que se "
+"calculan sus saldos. Debido a que consume espacio, no permitimos usarlo "
+"mientras hacemos una comparación."
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__2
+msgid "Title 2 (bold)"
+msgstr "Título 2 (negrita)"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__style_overwrite__3
+msgid "Title 3 (bold, smaller)"
+msgstr "Título 3 (negrita, más pequeña)"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_agedpartnerbalance
+#, fuzzy
+msgid "Total"
+msgstr "Total"
+
+#. module: accounting_pdf_reports
+#: model:ir.actions.act_window,name:accounting_pdf_reports.action_account_balance_menu
+#: model:ir.actions.report,name:accounting_pdf_reports.action_report_trial_balance
+#: model:ir.ui.menu,name:accounting_pdf_reports.menu_general_balance_report
+msgid "Trial Balance"
+msgstr "Balance de Comprobación"
+
+#. module: accounting_pdf_reports
+#: model:ir.model,name:accounting_pdf_reports.model_account_balance_report
+#: model:ir.model,name:accounting_pdf_reports.model_report_accounting_pdf_reports_report_trialbalance
+msgid "Trial Balance Report"
+msgstr "Informe de Balance de Comprobación"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_account_type__type
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_financial_report__type
+msgid "Type"
+msgstr "Tipo"
+
+#. module: accounting_pdf_reports
+#. odoo-python
+#: code:addons/accounting_pdf_reports/report/report_aged_partner.py:0
+#, python-format
+msgid "Unknown Partner"
+msgstr "Empresa desconocida"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_financial_report__type__sum
+msgid "View"
+msgstr "Ver"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_common_journal_report__amount_currency
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_print_journal__amount_currency
+#: model:ir.model.fields,field_description:accounting_pdf_reports.field_account_report_partner_ledger__amount_currency
+msgid "With Currency"
+msgstr "Con moneda"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_balance_report__display_account__not_zero
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_account_report__display_account__not_zero
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_general_ledger__display_account__not_zero
+msgid "With balance is not equal to 0"
+msgstr "Con saldo no es igual a 0"
+
+#. module: accounting_pdf_reports
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "With balance not equal to zero"
+msgstr "Con saldo no igual a cero"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_balance_report__display_account__movement
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_common_account_report__display_account__movement
+#: model:ir.model.fields.selection,name:accounting_pdf_reports.selection__account_report_general_ledger__display_account__movement
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_general_ledger
+#: model_terms:ir.ui.view,arch_db:accounting_pdf_reports.report_trialbalance
+msgid "With movements"
+msgstr "Con movimientos"
+
+#. module: accounting_pdf_reports
+#: model:ir.model.fields,help:accounting_pdf_reports.field_account_financial_report__style_overwrite
+msgid ""
+"You can set up here the format you want this record to be displayed. If you "
+"leave the automatic formatting, it will be computed based on the financial "
+"reports hierarchy (auto-computed field 'level')."
+msgstr ""
+"Puede configurar aquí el formato en el que desea que se muestre este "
+"registro. Si deja el formato automático, se calculará en función de la "
+"jerarquía de informes financieros (\"nivel\" de campo calculado "
+"automáticamente)."
+
+#. module: accounting_pdf_reports
+#. odoo-python
+#: code:addons/accounting_pdf_reports/wizard/account_general_ledger.py:0
+#, python-format
+msgid "You must define a Start Date"
+msgstr "Debes definir una Fecha de Inicio"
+
+#. module: accounting_pdf_reports
+#. odoo-python
+#: code:addons/accounting_pdf_reports/wizard/aged_partner.py:0
+#, python-format
+msgid "You must set a period length greater than 0."
+msgstr "Debe establecer una duración del período superior a 0."
+
+#. module: accounting_pdf_reports
+#. odoo-python
+#: code:addons/accounting_pdf_reports/wizard/aged_partner.py:0
+#, python-format
+msgid "You must set a start date."
+msgstr "Debe establecer una fecha de inicio."

--- a/om_account_accountant/i18n/es_CR.po
+++ b/om_account_accountant/i18n/es_CR.po
@@ -1,0 +1,239 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_account_accountant
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 20:34+0000\n"
+"PO-Revision-Date: 2023-07-08 14:36-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_account_accountant
+#: model:ir.actions.act_window,name:om_account_accountant.action_account_group_action
+#: model:ir.ui.menu,name:om_account_accountant.menu_account_group
+#, fuzzy
+msgid "Account Groups"
+msgstr "Grupos de Cuentas"
+
+#. module: om_account_accountant
+#: model:ir.actions.act_window,name:om_account_accountant.action_account_account_tag
+#: model:ir.ui.menu,name:om_account_accountant.menu_account_tag
+#, fuzzy
+msgid "Account Tags"
+msgstr "Etiquetas de Cuenta"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_seacrh
+#, fuzzy
+msgid "Account Template"
+msgstr "Plantilla de Cuenta"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.res_config_settings_view_form
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_partner_property_form
+#, fuzzy
+msgid "Accounting"
+msgstr "Contabilidad"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.res_config_settings_view_form
+#, fuzzy
+msgid "Anglo-Saxon Accounting"
+msgstr "Contabilidad Anglosajona"
+
+#. module: om_account_accountant
+#: model:ir.ui.menu,name:om_account_accountant.menu_accounting_statement_bank
+#, fuzzy
+msgid "Bank Statements"
+msgstr "Extractos Bancarios"
+
+#. module: om_account_accountant
+#: model:ir.ui.menu,name:om_account_accountant.menu_accounting_bank_and_cash
+#: model:ir.ui.menu,name:om_account_accountant.menu_action_account_moves_journal_bank_cash
+#, fuzzy
+msgid "Bank and Cash"
+msgstr "Banco y Efectivo"
+
+#. module: om_account_accountant
+#: model:ir.ui.menu,name:om_account_accountant.menu_accounting_statement_cash
+#, fuzzy
+msgid "Cash Registers"
+msgstr "Cajas Registradoras"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_form
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_tree
+#, fuzzy
+msgid "Chart of Accounts Template"
+msgstr "Plantilla de Plan de Cuentas"
+
+#. module: om_account_accountant
+#: model:ir.actions.act_window,name:om_account_accountant.action_account_chart_template_form
+#: model:ir.ui.menu,name:om_account_accountant.menu_account_coa_template
+#, fuzzy
+msgid "Chart of Accounts Templates"
+msgstr "Plantillas de Plan Contable"
+
+#. module: om_account_accountant
+#: model:ir.model,name:om_account_accountant.model_res_config_settings
+msgid "Config Settings"
+msgstr "Opciones de Configuración"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_form
+#, fuzzy
+msgid "Default Taxes"
+msgstr "Impuestos Predeterminados"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_seacrh
+#, fuzzy
+msgid "Expense Account"
+msgstr "Cuenta de Gasto"
+
+#. module: om_account_accountant
+#: model:ir.actions.act_window,name:om_account_accountant.action_account_fiscal_position_template
+#: model:ir.ui.menu,name:om_account_accountant.menu_account_fiscal_position_template
+#, fuzzy
+msgid "Fiscal Position Templates"
+msgstr "Plantillas de Posición Fiscal"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_seacrh
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_payment_method_search
+#, fuzzy
+msgid "Group By"
+msgstr "Agrupar Por"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_seacrh
+#, fuzzy
+msgid "Income Account"
+msgstr "Cuenta de Ingresos"
+
+#. module: om_account_accountant
+#: model:ir.model,name:om_account_accountant.model_account_move
+msgid "Journal Entry"
+msgstr "Asiento Contable"
+
+#. module: om_account_accountant
+#: model:ir.ui.menu,name:om_account_accountant.menu_finance_entries_accounting_journals
+#, fuzzy
+msgid "Journals"
+msgstr "Diarios Contables"
+
+#. module: om_account_accountant
+#: model:ir.ui.menu,name:om_account_accountant.menu_action_account_moves_journal_misc
+#, fuzzy
+msgid "Miscellaneous"
+msgstr "Varios"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_seacrh
+#, fuzzy
+msgid "Payable Account"
+msgstr "Cuenta por Pagar"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_payment_method_search
+#, fuzzy
+msgid "Payment Method"
+msgstr "Método de Pago"
+
+#. module: om_account_accountant
+#: model:ir.actions.act_window,name:om_account_accountant.action_account_payment_method
+#: model:ir.ui.menu,name:om_account_accountant.menu_account_payment_method
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_payment_method_form
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_payment_method_search
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_payment_method_tree
+#, fuzzy
+msgid "Payment Methods"
+msgstr "Métodos de Pago"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_payment_method_search
+#, fuzzy
+msgid "Payment Type"
+msgstr "Tipo de Pago"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_form
+#, fuzzy
+msgid "Properties"
+msgstr "Propiedades"
+
+#. module: om_account_accountant
+#: model:ir.ui.menu,name:om_account_accountant.menu_action_account_moves_journal_purchase
+#, fuzzy
+msgid "Purchases"
+msgstr "Compras"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_seacrh
+#, fuzzy
+msgid "Receivable Account"
+msgstr "Cuenta por Cobrar"
+
+#. module: om_account_accountant
+#: model:ir.actions.server,name:om_account_accountant.action_account_reconciliation
+#, fuzzy
+msgid "Reconcile"
+msgstr "Conciliar"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.res_config_settings_view_form
+#, fuzzy
+msgid ""
+"Record the cost of a good as an expense when this good is\n"
+"                                invoiced to a final customer (instead "
+"of recording the cost as soon\n"
+"                                as the product is received in stock)."
+msgstr ""
+"Registre el costo de un bien como un gasto cuando este bien es\n"
+"                                facturado a un cliente final (en lugar "
+"de registrar el costo tan pronto\n"
+"                                a medida que el producto se recibe en "
+"stock)."
+
+#. module: om_account_accountant
+#: model:ir.model.fields,help:om_account_accountant.field_res_config_settings__anglo_saxon_accounting
+#, fuzzy
+msgid ""
+"Record the cost of a good as an expense when this good is invoiced to a "
+"final customer."
+msgstr ""
+"Registre el costo de un bien como un gasto cuando este bien se facture "
+"a un cliente final."
+
+#. module: om_account_accountant
+#: model:ir.ui.menu,name:om_account_accountant.menu_action_account_moves_journal_sales
+#, fuzzy
+msgid "Sales"
+msgstr "Ventas"
+
+#. module: om_account_accountant
+#: model_terms:ir.ui.view,arch_db:om_account_accountant.view_account_chart_template_seacrh
+#, fuzzy
+msgid "Search Chart of Account Templates"
+msgstr "Buscar Plantillas de Plan de Cuentas"
+
+#. module: om_account_accountant
+#: model:ir.ui.menu,name:om_account_accountant.menu_account_templates
+#, fuzzy
+msgid "Templates"
+msgstr "Plantillas"
+
+#. module: om_account_accountant
+#: model:ir.model.fields,field_description:om_account_accountant.field_res_config_settings__anglo_saxon_accounting
+#, fuzzy
+msgid "Use anglo-saxon accounting"
+msgstr "Usar Contabilidad Anglosajona"

--- a/om_account_asset/i18n/es_CR.po
+++ b/om_account_asset/i18n/es_CR.po
@@ -1,0 +1,1594 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_account_asset
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 20:39+0000\n"
+"PO-Revision-Date: 2023-07-08 14:41-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, python-format
+msgid " (copy)"
+msgstr " (copia)"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid " (grouped)"
+msgstr " (agrupados)"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__entry_count
+#, fuzzy
+msgid "# Asset Entries"
+msgstr "# Entradas de Activos"
+
+#. module: om_account_asset
+#: model:ir.actions.server,name:om_account_asset.account_asset_cron_ir_actions_server model:ir.cron,cron_name:om_account_asset.account_asset_cron
+#, fuzzy
+msgid "Account Asset: Generate asset entries"
+msgstr "Activo de cuenta: Generar entradas de activos"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_depreciation_confirmation_wizard__date
+#, fuzzy
+msgid "Account Date"
+msgstr "Fecha Contable"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__account_depreciation_id
+#, fuzzy
+msgid "Account used in the depreciation entries, to decrease the asset value."
+msgstr "Cuenta utilizada en las entradas de depreciación, para disminuir el valor del activo."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__account_depreciation_expense_id
+#, fuzzy
+msgid "Account used in the periodical entries, to record a part of the asset as expense."
+msgstr "Cuenta utilizada en las entradas periódicas, para registrar una parte del activo como gasto."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__account_asset_id
+#, fuzzy
+msgid "Account used to record the purchase of the asset at its original price."
+msgstr "Cuenta utilizada para registrar la compra del activo a su precio original."
+
+#. module: om_account_asset
+#. odoo-javascript
+#: code:addons/om_account_asset/static/src/js/account_asset.js:0
+#, fuzzy, python-format
+msgid "Accounting entries waiting for manual verification"
+msgstr "Anotaciones contables en espera de verificación manual"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_needaction
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_needaction
+#, fuzzy
+msgid "Action Needed"
+msgstr "Acción Necesaria"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__active
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__active
+#, fuzzy
+msgid "Active"
+msgstr "Activo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__activity_ids
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__activity_ids
+#, fuzzy
+msgid "Activities"
+msgstr "Actividades"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__activity_exception_decoration
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__activity_exception_decoration
+#, fuzzy
+msgid "Activity Exception Decoration"
+msgstr "Decoración de Excepción de Actividad"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__activity_state
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__activity_state
+#, fuzzy
+msgid "Activity State"
+msgstr "Estado de Actividad"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__activity_type_icon
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__activity_type_icon
+#, fuzzy
+msgid "Activity Type Icon"
+msgstr "Icono de tipo de actividad"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "Additional Options"
+msgstr "Opciones adicionales"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "Amount"
+msgstr "Importe"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__depreciation_value
+#, fuzzy
+msgid "Amount of Depreciation Lines"
+msgstr "Cantidad de líneas de depreciación"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__installment_value
+#, fuzzy
+msgid "Amount of Installment Lines"
+msgstr "Cantidad de líneas de pago a plazos"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__analytic_distribution
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__analytic_distribution
+#, fuzzy
+msgid "Analytic"
+msgstr "Analítico"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__account_analytic_id
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__account_analytic_id
+#, fuzzy
+msgid "Analytic Account"
+msgstr "Cuenta Analítica"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__analytic_distribution_search
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__analytic_distribution_search
+#, fuzzy
+msgid "Analytic Distribution Search"
+msgstr "Búsqueda de distribución Analítica"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__analytic_precision
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__analytic_precision
+#, fuzzy
+msgid "Analytic Precision"
+msgstr "Precisión Analítica"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__asset_id
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__asset_id
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_search
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Asset"
+msgstr "Activo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__account_asset_id
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_search
+#, fuzzy
+msgid "Asset Account"
+msgstr "Cuenta de Activos"
+
+#. module: om_account_asset
+#: model:ir.actions.act_window,name:om_account_asset.action_account_asset_asset_list_normal_purchase
+#: model:ir.model.fields,field_description:om_account_asset.field_account_move_line__asset_category_id
+#: model:ir.ui.menu,name:om_account_asset.menu_action_account_asset_asset_list_normal_purchase
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_purchase_tree
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_search
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_invoice_asset_category
+#, fuzzy
+msgid "Asset Category"
+msgstr "Categoría de Activos"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.asset_modify_form
+#, fuzzy
+msgid "Asset Durations to Modify"
+msgstr "Duraciones de Activos para Modificar"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_move_line__asset_end_date
+#, fuzzy
+msgid "Asset End Date"
+msgstr "Fecha de Finalización del Activo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__asset_method_time
+#, fuzzy
+msgid "Asset Method Time"
+msgstr "Tiempo del Método de Activos"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__name
+#, fuzzy
+msgid "Asset Name"
+msgstr "Nombre del Activo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_move_line__asset_start_date
+#, fuzzy
+msgid "Asset Start Date"
+msgstr "Fecha de Inicio del Activo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__name
+#: model:ir.model.fields,field_description:om_account_asset.field_product_product__asset_category_id
+#: model:ir.model.fields,field_description:om_account_asset.field_product_template__asset_category_id
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "Asset Type"
+msgstr "Tipo de Activo"
+
+#. module: om_account_asset
+#: model:ir.model,name:om_account_asset.model_account_asset_category
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__asset_category_id
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_tree
+#, fuzzy
+msgid "Asset category"
+msgstr "Categoría de activos"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "Asset created"
+msgstr "Activo creado"
+
+#. module: om_account_asset
+#: model:ir.model,name:om_account_asset.model_account_asset_depreciation_line
+#, fuzzy
+msgid "Asset depreciation line"
+msgstr "Línea de amortización de activos"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "Asset sold or disposed. Accounting entry awaiting for validation."
+msgstr "Activo vendido o enajenado. Anotación contable pendiente de validación."
+
+#. module: om_account_asset
+#: model:ir.model,name:om_account_asset.model_account_asset_asset
+#, fuzzy
+msgid "Asset/Revenue Recognition"
+msgstr "Reconocimiento de Activos/Ingresos"
+
+#. module: om_account_asset
+#: model:ir.actions.act_window,name:om_account_asset.action_account_asset_asset_form
+#: model:ir.model.fields,field_description:om_account_asset.field_account_bank_statement_line__asset_ids
+#: model:ir.model.fields,field_description:om_account_asset.field_account_move__asset_ids
+#: model:ir.model.fields,field_description:om_account_asset.field_account_payment__asset_ids
+#: model:ir.ui.menu,name:om_account_asset.menu_action_account_asset_asset_form model:ir.ui.menu,name:om_account_asset.menu_action_asset_asset_report
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_purchase_tree
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_search
+#, fuzzy
+msgid "Assets"
+msgstr "Activos"
+
+#. module: om_account_asset
+#: model:ir.actions.act_window,name:om_account_asset.action_asset_asset_report model:ir.model,name:om_account_asset.model_asset_asset_report
+#: model_terms:ir.ui.view,arch_db:om_account_asset.action_account_asset_report_graph
+#: model_terms:ir.ui.view,arch_db:om_account_asset.action_account_asset_report_pivot
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Assets Analysis"
+msgstr "Análisis de Activos"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_bank_statement_line__asset_depreciation_ids
+#: model:ir.model.fields,field_description:om_account_asset.field_account_move__asset_depreciation_ids
+#: model:ir.model.fields,field_description:om_account_asset.field_account_payment__asset_depreciation_ids
+#, fuzzy
+msgid "Assets Depreciation Lines"
+msgstr "Líneas de Amortización de Activos"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_search
+#, fuzzy
+msgid "Assets in closed state"
+msgstr "Activos en estado cerrado"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_search
+#, fuzzy
+msgid "Assets in draft and open states"
+msgstr "Activos en estado de borrador y abierto"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Assets in draft state"
+msgstr "Activos en estado de borrador"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Assets in running state"
+msgstr "Activos en estado de ejecución"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_attachment_count
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_attachment_count
+#, fuzzy
+msgid "Attachment Count"
+msgstr "Recuento de archivos adjuntos"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__open_asset
+#, fuzzy
+msgid "Auto-Confirm Assets"
+msgstr "Confirmación automática de activos"
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_asset__date_first_depreciation__last_day_period
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_category__date_first_depreciation__last_day_period
+#, fuzzy
+msgid "Based on Last Day of Purchase Period"
+msgstr "Basado en el último día del período de compra"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.asset_modify_form
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_depreciation_confirmation_wizard
+#, fuzzy
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__category_id
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_search
+#, fuzzy
+msgid "Category"
+msgstr "Categoría"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Category of asset"
+msgstr "Categoría del activo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__open_asset
+#, fuzzy
+msgid "Check this if you want to automatically confirm the assets of this category when created by invoices."
+msgstr "Marque esta opción si desea confirmar automáticamente los activos de esta categoría cuando se crean mediante facturas."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__group_entries
+#, fuzzy
+msgid "Check this if you want to group the generated entries by categories."
+msgstr "Marque esta opción si desea agrupar las entradas generadas por categorías."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__method
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__method
+#, fuzzy
+msgid ""
+"Choose the method to use to compute the amount of depreciation lines.\n"
+"  * Linear: Calculated on basis of: Gross Value / Number of Depreciations\n"
+"  * Degressive: Calculated on basis of: Residual Value * Degressive Factor"
+msgstr ""
+"Elija el método que desea utilizar para calcular la cantidad de líneas de amortización.\n"
+"  * Lineal: Calculado sobre la base de: Valor bruto / Número de depreciaciones\n"
+"  * Degresivo: Calculado sobre la base de: Valor residual * Factor degresivo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__method_time
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__method_time
+#, fuzzy
+msgid ""
+"Choose the method to use to compute the dates and number of entries.\n"
+"  * Number of Entries: Fix the number of entries and the time between 2 depreciations.\n"
+"  * Ending Date: Choose the time between 2 depreciations and the date the depreciations won't go beyond."
+msgstr ""
+"Elija el método que desea utilizar para calcular las fechas y el número de entradas.\n"
+"  * Número de entradas: Fija el número de entradas y el tiempo entre 2 depreciaciones.\n"
+"  * Fecha de finalización: Elija el tiempo entre 2 depreciaciones y la fecha en que las depreciaciones no irán más allá."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_asset_depreciation_confirmation_wizard__date
+#, fuzzy
+msgid "Choose the period for which you want to automatically post the depreciation lines of running assets"
+msgstr "Elija el período durante el cual desea contabilizar automáticamente las líneas de amortización de los activos en ejecución"
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_asset__state__close
+#: model:ir.model.fields.selection,name:om_account_asset.selection__asset_asset_report__state__close
+#, fuzzy
+msgid "Close"
+msgstr "Cerrar"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_search
+#, fuzzy
+msgid "Closed"
+msgstr "Cerrado"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__company_id
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__company_id
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__company_id
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Company"
+msgstr "Compañía"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__method
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__method
+#, fuzzy
+msgid "Computation Method"
+msgstr "Método de cálculo"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_depreciation_confirmation_wizard
+#, fuzzy
+msgid "Compute Asset"
+msgstr "Activo informático"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Compute Depreciation"
+msgstr "Calcular depreciación"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/wizard/asset_depreciation_confirmation_wizard.py:0
+#, fuzzy, python-format
+msgid "Created Asset Moves"
+msgstr "Movimientos de activos creados"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/wizard/asset_depreciation_confirmation_wizard.py:0
+#, fuzzy, python-format
+msgid "Created Revenue Moves"
+msgstr "Movimientos de ingresos creados"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__create_uid
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__create_uid
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__create_uid
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_depreciation_confirmation_wizard__create_uid
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__create_uid
+#, fuzzy
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__create_date
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__create_date
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__create_date
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_depreciation_confirmation_wizard__create_date
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__create_date
+#, fuzzy
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__depreciated_value
+#, fuzzy
+msgid "Cumulative Depreciation"
+msgstr "Depreciación acumulada"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0 model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__currency_id
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__currency_id
+#, fuzzy, python-format
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_search
+#, fuzzy
+msgid "Current"
+msgstr "Actual"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__amount
+#, fuzzy
+msgid "Current Depreciation"
+msgstr "Depreciación actual"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__date
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__date
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_search
+#, fuzzy
+msgid "Date"
+msgstr "Fecha"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Date of asset"
+msgstr "Fecha del activo"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Date of asset purchase"
+msgstr "Fecha de compra del activo"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Date of depreciation"
+msgstr "Fecha de amortización"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "Deferred Revenue Account"
+msgstr "Cuenta de ingresos diferidos"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_product_product__deferred_revenue_category_id
+#: model:ir.model.fields,field_description:om_account_asset.field_product_template__deferred_revenue_category_id
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "Deferred Revenue Type"
+msgstr "Tipo de ingresos diferidos"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_search
+#, fuzzy
+msgid "Deferred Revenues"
+msgstr "Ingresos diferidos"
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_asset__method__degressive
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_category__method__degressive
+#, fuzzy
+msgid "Degressive"
+msgstr "Decrecientes"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__method_progress_factor
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__method_progress_factor
+#, fuzzy
+msgid "Degressive Factor"
+msgstr "Factor degresivo"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Depreciation"
+msgstr "Depreciación"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Depreciation Board"
+msgstr "Junta de Depreciación"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__depreciation_nbr
+#, fuzzy
+msgid "Depreciation Count"
+msgstr "Recuento de depreciación"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__depreciation_date
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__depreciation_date
+#, fuzzy
+msgid "Depreciation Date"
+msgstr "Fecha de amortización"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__date_first_depreciation
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__date_first_depreciation
+#, fuzzy
+msgid "Depreciation Dates"
+msgstr "Fechas de depreciación"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__account_depreciation_id
+#, fuzzy
+msgid "Depreciation Entries: Asset Account"
+msgstr "Asientos de amortización: Cuenta de activos"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__account_depreciation_expense_id
+#, fuzzy
+msgid "Depreciation Entries: Expense Account"
+msgstr "Asientos de depreciación: Cuenta de gastos"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__move_id
+#, fuzzy
+msgid "Depreciation Entry"
+msgstr "Entrada de depreciación"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Depreciation Information"
+msgstr "Información de depreciación"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__depreciation_line_ids
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Depreciation Lines"
+msgstr "Líneas de depreciación"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "Depreciation Method"
+msgstr "Método de depreciación"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Depreciation Month"
+msgstr "Mes de depreciación"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__name
+#, fuzzy
+msgid "Depreciation Name"
+msgstr "Nombre de depreciación"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/wizard/asset_modify.py:0
+#, fuzzy, python-format
+msgid "Depreciation board modified"
+msgstr "Junta de amortización modificada"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "Depreciation line posted."
+msgstr "Línea de amortización contabilizada."
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__display_name
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__display_name
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__display_name
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__display_name
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_depreciation_confirmation_wizard__display_name
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__display_name
+#, fuzzy
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "Disposal Move"
+msgstr "Mudanza de eliminación"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "Disposal Moves"
+msgstr "Movimientos de eliminación"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "Document closed."
+msgstr "Documento cerrado."
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_asset__state__draft
+#: model:ir.model.fields.selection,name:om_account_asset.selection__asset_asset_report__state__draft
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Draft"
+msgstr "Borrador"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__method_end
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_asset__method_time__end
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_category__method_time__end
+#, fuzzy
+msgid "Ending Date"
+msgstr "Fecha de finalización"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__method_end
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__method_end
+#, fuzzy
+msgid "Ending date"
+msgstr "Fecha de finalización"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Extended Filters..."
+msgstr "Filtros extendidos..."
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__first_depreciation_manual_date
+#, fuzzy
+msgid "First Depreciation Date"
+msgstr "Primera fecha de amortización"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_follower_ids
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_follower_ids
+#, fuzzy
+msgid "Followers"
+msgstr "Seguidores"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_partner_ids
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_partner_ids
+#, fuzzy
+msgid "Followers (Partners)"
+msgstr "Seguidores (Socios)"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__activity_type_icon
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__activity_type_icon
+#, fuzzy
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr "Icono de Fotn awesome, por ejemplo fa-tasks"
+
+#. module: om_account_asset
+#: model_terms:ir.actions.act_window,help:om_account_asset.action_asset_asset_report
+#, fuzzy
+msgid ""
+"From this report, you can have an overview on all depreciations. The\n"
+"            search bar can also be used to personalize your assets depreciation reporting."
+msgstr ""
+"A partir de este informe, puede tener una visión general de todas las depreciaciones. El\n"
+"            La barra de búsqueda también se puede utilizar para personalizar sus informes de depreciación de activos."
+
+#. module: om_account_asset
+#: model:ir.ui.menu,name:om_account_asset.menu_asset_depreciation_confirmation_wizard
+#, fuzzy
+msgid "Generate Assets Entries"
+msgstr "Generar entradas de activos"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_depreciation_confirmation_wizard
+#, fuzzy
+msgid "Generate Entries"
+msgstr "Generar asientos"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__gross_value
+#, fuzzy
+msgid "Gross Amount"
+msgstr "Importe bruto"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__value
+#, fuzzy
+msgid "Gross Value"
+msgstr "Valor bruto"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Gross value of asset"
+msgstr "Valor bruto del activo"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Group By"
+msgstr "Agrupar por"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_search
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_search
+msgid "Group By..."
+msgstr "Agrupar Por..."
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__group_entries
+#, fuzzy
+msgid "Group Journal Entries"
+msgstr "Entradas de diario del grupo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__has_message
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__has_message
+#, fuzzy
+msgid "Has Message"
+msgstr "Tiene mensaje"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__id
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__id
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__id
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__id
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_depreciation_confirmation_wizard__id
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__id
+#, fuzzy
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__activity_exception_icon
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__activity_exception_icon
+#, fuzzy
+msgid "Icon"
+msgstr "Icono"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__activity_exception_icon
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__activity_exception_icon
+#, fuzzy
+msgid "Icon to indicate an exception activity."
+msgstr "Icono para indicar una actividad de excepción."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__message_needaction
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__message_needaction
+#, fuzzy
+msgid "If checked, new messages require your attention."
+msgstr "Si está marcado, los nuevos mensajes requieren su atención."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__message_has_error
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__message_has_sms_error
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__message_has_error
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__message_has_sms_error
+#, fuzzy
+msgid "If checked, some messages have a delivery error."
+msgstr "Si está marcada, algunos mensajes tienen un error de entrega."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__prorata
+#, fuzzy
+msgid ""
+"Indicates that the first depreciation entry for this asset have to be done from the asset date (purchase date) instead of the first January / Start "
+"date of fiscal year"
+msgstr ""
+"Indica que la primera entrada de depreciación para este activo debe realizarse a partir de la fecha del activo (fecha de compra) en lugar de la "
+"primera fecha de enero / inicio del año fiscal"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__prorata
+#, fuzzy
+msgid "Indicates that the first depreciation entry for this asset have to be done from the purchase date instead of the first of January"
+msgstr "Indica que la primera entrada de depreciación para este activo debe hacerse a partir de la fecha de compra en lugar del primero de enero"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__installment_nbr
+#, fuzzy
+msgid "Installment Count"
+msgstr "Recuento de cuotas"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__invoice_id
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_is_follower
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_is_follower
+#, fuzzy
+msgid "Is Follower"
+msgstr "Es seguidor"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__salvage_value
+#, fuzzy
+msgid "It is the amount you plan to have that you cannot depreciate."
+msgstr "Es la cantidad que planea tener que no puede depreciar."
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Items"
+msgstr "Artículos"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__journal_id
+#, fuzzy
+msgid "Journal"
+msgstr "Diario"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0 model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy, python-format
+msgid "Journal Entries"
+msgstr "Asientos contables"
+
+#. module: om_account_asset
+#: model:ir.model,name:om_account_asset.model_account_move
+msgid "Journal Entry"
+msgstr "Asiento contable"
+
+#. module: om_account_asset
+#: model:ir.model,name:om_account_asset.model_account_move_line
+msgid "Journal Item"
+msgstr "Apunte contable"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset____last_update
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category____last_update
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line____last_update
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report____last_update
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_depreciation_confirmation_wizard____last_update
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify____last_update
+#, fuzzy
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__write_uid
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__write_uid
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__write_uid
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_depreciation_confirmation_wizard__write_uid
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__write_uid
+#, fuzzy
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__write_date
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__write_date
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__write_date
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_depreciation_confirmation_wizard__write_date
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__write_date
+#, fuzzy
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_asset__method__linear
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_category__method__linear
+#, fuzzy
+msgid "Linear"
+msgstr "Lineal"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__move_check
+#, fuzzy
+msgid "Linked"
+msgstr "Enlazado"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_main_attachment_id
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_main_attachment_id
+#, fuzzy
+msgid "Main Attachment"
+msgstr "Archivo adjunto principal"
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_asset__date_first_depreciation__manual
+#, fuzzy
+msgid "Manual"
+msgstr "Manual"
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_category__date_first_depreciation__manual
+#, fuzzy
+msgid "Manual (Defaulted on Purchase Date)"
+msgstr "Manual (predeterminado en la fecha de compra)"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_has_error
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_has_error
+#, fuzzy
+msgid "Message Delivery error"
+msgstr "Error de entrega de mensajes"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_ids
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_ids
+#, fuzzy
+msgid "Messages"
+msgstr "Mensajes"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.asset_modify_form
+#, fuzzy
+msgid "Modify"
+msgstr "Modifica importe del impuesto"
+
+#. module: om_account_asset
+#: model:ir.actions.act_window,name:om_account_asset.action_asset_modify model:ir.model,name:om_account_asset.model_asset_modify
+#: model_terms:ir.ui.view,arch_db:om_account_asset.asset_modify_form
+#, fuzzy
+msgid "Modify Asset"
+msgstr "Modificar activo"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Modify Depreciation"
+msgstr "Modificar depreciación"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_move_line__asset_mrr
+#, fuzzy
+msgid "Monthly Recurring Revenue"
+msgstr "Ingresos recurrentes mensuales"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__my_activity_date_deadline
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__my_activity_date_deadline
+#, fuzzy
+msgid "My Activity Deadline"
+msgstr "Fecha límite de mi actividad"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__activity_date_deadline
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__activity_date_deadline
+#, fuzzy
+msgid "Next Activity Deadline"
+msgstr "Fecha límite de la próxima actividad"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__activity_summary
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__activity_summary
+#, fuzzy
+msgid "Next Activity Summary"
+msgstr "Resumen de la siguiente actividad"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__activity_type_id
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__activity_type_id
+#, fuzzy
+msgid "Next Activity Type"
+msgstr "Siguiente tipo de actividad"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__remaining_value
+#, fuzzy
+msgid "Next Period Depreciation"
+msgstr "Depreciación del próximo período"
+
+#. module: om_account_asset
+#: model_terms:ir.actions.act_window,help:om_account_asset.action_asset_asset_report
+#, fuzzy
+msgid "No content"
+msgstr "Sin contenido"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__note
+#, fuzzy
+msgid "Note"
+msgstr "Nota"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__first_depreciation_manual_date
+#, fuzzy
+msgid ""
+"Note that this date does not alter the computation of the first journal entry in case of prorata temporis assets. It simply changes its accounting date"
+msgstr ""
+"Tenga en cuenta que esta fecha no altera el cómputo de la primera entrada del diario en el caso de activos prorata temporis. Simplemente cambia su "
+"fecha contable"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_needaction_counter
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_needaction_counter
+#, fuzzy
+msgid "Number of Actions"
+msgstr "Número de acciones"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__method_number
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__method_number
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__method_number
+#, fuzzy
+msgid "Number of Depreciations"
+msgstr "Número de depreciaciones"
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_asset__method_time__number
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_category__method_time__number
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "Number of Entries"
+msgstr "Número de entradas"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__method_period
+#, fuzzy
+msgid "Number of Months in a Period"
+msgstr "Número de meses en un periodo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_has_error_counter
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_has_error_counter
+#, fuzzy
+msgid "Number of errors"
+msgstr "Número de errores"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__message_needaction_counter
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__message_needaction_counter
+#, fuzzy
+msgid "Number of messages which requires an action"
+msgstr "Número de mensajes que requieren una acción"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__message_has_error_counter
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__message_has_error_counter
+#, fuzzy
+msgid "Number of messages with delivery error"
+msgstr "Número de mensajes con error de entrega"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "One Entry Every"
+msgstr "Una entrada cada"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0 model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__partner_id
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__partner_id
+#, fuzzy, python-format
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__method_period
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__method_period
+#, fuzzy
+msgid "Period Length"
+msgstr "Duración del período"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "Periodicity"
+msgstr "Periodicidad"
+
+#. module: om_account_asset
+#: model:ir.actions.act_window,name:om_account_asset.action_asset_depreciation_confirmation_wizard
+#, fuzzy
+msgid "Post Depreciation Lines"
+msgstr "Líneas de amortización posteriores"
+
+#. module: om_account_asset
+#. odoo-javascript
+#: code:addons/om_account_asset/static/src/js/account_asset.js:0
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__move_posted_check
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__move_check
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy, python-format
+msgid "Posted"
+msgstr "Publicado"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__posted_value
+#, fuzzy
+msgid "Posted Amount"
+msgstr "Cantidad publicada"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Posted depreciation lines"
+msgstr "Líneas de amortización contabilizadas"
+
+#. module: om_account_asset
+#: model:ir.model,name:om_account_asset.model_product_template
+msgid "Product"
+msgstr "Producto"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__prorata
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__prorata
+#, fuzzy
+msgid "Prorata Temporis"
+msgstr "Prorata Temporis"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "Prorata temporis can be applied only for the \"number of depreciations\" time method."
+msgstr "Prorata temporis sólo puede aplicarse al método de tiempo del \"número de depreciaciones\"."
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_search
+#, fuzzy
+msgid "Purchase"
+msgstr "Compra"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Purchase Month"
+msgstr "Mes de compra"
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_category__type__purchase
+#, fuzzy
+msgid "Purchase: Asset"
+msgstr "Compra: Activo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_modify__name
+#, fuzzy
+msgid "Reason"
+msgstr "Motivo"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "Recognition Account"
+msgstr "Cuenta de reconocimiento"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "Recognition Income Account"
+msgstr "Cuenta de Ingresos de Reconocimiento"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__code
+#, fuzzy
+msgid "Reference"
+msgstr "Referencia"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Residual"
+msgstr "Remanente"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__value_residual
+#, fuzzy
+msgid "Residual Value"
+msgstr "Valor residual"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__activity_user_id
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__activity_user_id
+#, fuzzy
+msgid "Responsible User"
+msgstr "Usuario responsable"
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_asset__state__open
+#: model:ir.model.fields.selection,name:om_account_asset.selection__asset_asset_report__state__open
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_asset_report_search
+#, fuzzy
+msgid "Running"
+msgstr "Corriente"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__message_has_sms_error
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__message_has_sms_error
+#, fuzzy
+msgid "SMS Delivery error"
+msgstr "Error de entrega de SMS"
+
+#. module: om_account_asset
+#: model:ir.model.fields.selection,name:om_account_asset.selection__account_asset_category__type__sale
+#, fuzzy
+msgid "Sale: Revenue Recognition"
+msgstr "Venta: Reconocimiento de ingresos"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_search
+#, fuzzy
+msgid "Sales"
+msgstr "Ventas"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__salvage_value
+#, fuzzy
+msgid "Salvage Value"
+msgstr "Valor de recuperación"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_search
+#, fuzzy
+msgid "Search Asset Category"
+msgstr "Categoría de activos de búsqueda"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Sell or Dispose"
+msgstr "Vender o disponer"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__sequence
+#, fuzzy
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "Set to Draft"
+msgstr "Restablecer a borrador"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__method_period
+#, fuzzy
+msgid "State here the time between 2 depreciations, in months"
+msgstr "Indique aquí el tiempo entre 2 depreciaciones, en meses"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_depreciation_line__parent_state
+#, fuzzy
+msgid "State of Asset"
+msgstr "Estado del activo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__state
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__state
+#, fuzzy
+msgid "Status"
+msgstr "Estado"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__activity_state
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__activity_state
+#, fuzzy
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+"Estado basado en actividades\n"
+"Atrasado: la fecha de vencimiento ya pasó\n"
+"Hoy: la fecha de la actividad es hoy\n"
+"Planificado: Actividades futuras."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__method_period
+#, fuzzy
+msgid "The amount of time between two depreciations, in months"
+msgstr "La cantidad de tiempo entre dos depreciaciones, en meses"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/wizard/asset_modify.py:0
+#, fuzzy, python-format
+msgid "The number of depreciations must be greater than the number of posted or draft entries to allow for complete depreciation of the asset."
+msgstr ""
+"El número de amortizaciones debe ser mayor que el número de entradas contabilizadas o en borrador para permitir la depreciación completa del activo."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__method_number
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__method_number
+msgid "The number of depreciations needed to depreciate your asset"
+msgstr "El número de depreciaciones necesarias para que el activo se deprecie"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_move.py:0
+#, fuzzy, python-format
+msgid "The number of depreciations or the period length of your asset category cannot be 0."
+msgstr "El número de amortizaciones o la duración del período de su categoría de activos no puede ser 0."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__date_first_depreciation
+#, fuzzy
+msgid ""
+"The way to compute the date of the first depreciation.\n"
+"  * Based on last day of purchase period: The depreciation dates will be based on the last day of the purchase month or the purchase year (depending "
+"on the periodicity of the depreciations).\n"
+"  * Based on purchase date: The depreciation dates will be based on the purchase date."
+msgstr ""
+"La forma de calcular la fecha de la primera depreciación.\n"
+"  * Basado en el último día del período de compra: Las fechas de depreciación se basarán en el último día del mes de compra o el año de compra "
+"(dependiendo de la periodicidad de las depreciaciones).\n"
+"  * Basado en la fecha de compra: Las fechas de depreciación se basarán en la fecha de compra."
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__date_first_depreciation
+#, fuzzy
+msgid ""
+"The way to compute the date of the first depreciation.\n"
+"  * Based on last day of purchase period: The depreciation dates will be based on the last day of the purchase month or the purchase year (depending "
+"on the periodicity of the depreciations).\n"
+"  * Based on purchase date: The depreciation dates will be based on the purchase date.\n"
+msgstr ""
+"La forma de calcular la fecha de la primera depreciación.\n"
+"  * Basado en el último día del período de compra: Las fechas de depreciación se basarán en el último día del mes de compra o el año de compra "
+"(dependiendo de la periodicidad de las depreciaciones).\n"
+"  * Basado en la fecha de compra: Las fechas de depreciación se basarán en la fecha de compra.\n"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "This depreciation is already linked to a journal entry. Please post or delete it."
+msgstr "Esta depreciación ya está vinculada a una entrada de diario. Por favor, publíquelo o elimínelo."
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_asset_depreciation_confirmation_wizard
+#, fuzzy
+msgid ""
+"This wizard will post installment/depreciation lines for the selected month.<br/>\n"
+"                        This will generate journal entries for all related installment lines on this period\n"
+"                        of asset/revenue recognition as well."
+msgstr ""
+"Este asistente registrará líneas de pago a plazos/depreciación para el mes seleccionado.<br/>Esto generará entradas de diario para todas las líneas de "
+"cuotas relacionadas en este período.\n"
+"                        de reconocimiento de activos/ingresos también."
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__method_time
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__method_time
+#, fuzzy
+msgid "Time Method"
+msgstr "Método Time"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "Time Method Based On"
+msgstr "Método de tiempo basado en"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__type
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__type
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_search
+#, fuzzy
+msgid "Type"
+msgstr "Tipo"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__activity_exception_decoration
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__activity_exception_decoration
+#, fuzzy
+msgid "Type of the exception activity on record."
+msgstr "Tipo de actividad de excepción registrada."
+
+#. module: om_account_asset
+#. odoo-javascript
+#: code:addons/om_account_asset/static/src/js/account_asset.js:0
+#, fuzzy, python-format
+msgid "Unposted"
+msgstr "Sin asentar"
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__unposted_value
+#, fuzzy
+msgid "Unposted Amount"
+msgstr "Cantidad no contabilizada"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_purchase_tree
+#, fuzzy
+msgid "Vendor"
+msgstr "Proveedor"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_move.py:0
+#, fuzzy, python-format
+msgid "Vendor bill cancelled."
+msgstr "Factura de proveedor cancelada."
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_asset__website_message_ids
+#: model:ir.model.fields,field_description:om_account_asset.field_account_asset_category__website_message_ids
+#, fuzzy
+msgid "Website Messages"
+msgstr "Mensajes del sitio web"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__website_message_ids
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_category__website_message_ids
+#, fuzzy
+msgid "Website communication history"
+msgstr "Historial de comunicación del sitio web"
+
+#. module: om_account_asset
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_asset__state
+#: model:ir.model.fields,help:om_account_asset.field_account_asset_depreciation_line__parent_state
+#, fuzzy
+msgid ""
+"When an asset is created, the status is 'Draft'.\n"
+"If the asset is confirmed, the status goes in 'Running' and the depreciation lines can be posted in the accounting.\n"
+"You can manually close an asset when the depreciation is over. If the last line of depreciation is posted, the asset automatically goes in that status."
+msgstr ""
+"Cuando se crea un activo, el estado es 'Borrador'.\n"
+"Si se confirma el activo, el estado va en 'En ejecución' y las líneas de depreciación se pueden contabilizar en la contabilidad.\n"
+"Puede cerrar manualmente un activo cuando finalice la depreciación. Si se contabiliza la última línea de amortización, el activo pasa automáticamente "
+"a ese estado."
+
+#. module: om_account_asset
+#: model:ir.model.fields,field_description:om_account_asset.field_asset_asset_report__name
+#, fuzzy
+msgid "Year"
+msgstr "Año"
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "You cannot delete a document that contains posted entries."
+msgstr "No puede eliminar un documento que contenga entradas publicadas."
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "You cannot delete a document that is in %s state."
+msgstr "No puede eliminar un documento que está en %s estado."
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "You cannot delete posted depreciation lines."
+msgstr "No puede eliminar las líneas de amortización registradas."
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_asset.py:0
+#, fuzzy, python-format
+msgid "You cannot delete posted installment lines."
+msgstr "No puede eliminar las líneas de pago publicadas."
+
+#. module: om_account_asset
+#. odoo-python
+#: code:addons/om_account_asset/models/account_move.py:0
+#, fuzzy, python-format
+msgid "You cannot reset to draft for an entry having a posted asset"
+msgstr "No se puede restablecer el borrador de una entrada que tiene un recurso registrado"
+
+#. module: om_account_asset
+#: model:ir.model,name:om_account_asset.model_asset_depreciation_confirmation_wizard
+#, fuzzy
+msgid "asset.depreciation.confirmation.wizard"
+msgstr "asset.depreciation.confirmation.wizard"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "e.g. Computers"
+msgstr "por ejemplo, ordenadores"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_asset_form
+#, fuzzy
+msgid "e.g. Laptop iBook"
+msgstr "por ejemplo, Laptop iBook"
+
+#. module: om_account_asset
+#: model_terms:ir.ui.view,arch_db:om_account_asset.asset_modify_form model_terms:ir.ui.view,arch_db:om_account_asset.view_account_asset_category_form
+#, fuzzy
+msgid "months"
+msgstr "meses"

--- a/om_account_bank_statement_import/i18n/es_CR.po
+++ b/om_account_bank_statement_import/i18n/es_CR.po
@@ -1,0 +1,1080 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_account_bank_statement_import
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 20:47+0000\n"
+"PO-Revision-Date: 2023-07-08 14:48-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, fuzzy, python-format
+msgid "%d transactions had already been imported and were ignored."
+msgstr "%d transacciones ya habían sido importadas y fueron ignoradas."
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, fuzzy, python-format
+msgid "1 transaction had already been imported and was ignored."
+msgstr "1 transacción ya había sido importada y fue ignorada."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.constraint,message:om_account_bank_statement_import.constraint_account_bank_statement_line_unique_import_id
+msgid "A bank account transactions can be imported only once !"
+msgstr "Las transacciones de una cuenta bancaria solo se pueden importar una vez!"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.actions.act_window,help:om_account_bank_statement_import.action_bank_statement_line
+#, fuzzy
+msgid "A bank statement line is a financial transaction on a bank account"
+msgstr "Una línea de extracto bancario es una transacción financiera de una cuenta bancaria"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__company_partner_id
+msgid "Account Holder"
+msgstr "Titular de la cuenta"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__bank_acc_number
+msgid "Account Number"
+msgstr "Número de cuenta"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_needaction
+#, fuzzy
+msgid "Action Needed"
+msgstr "Acción necesaria"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__active
+msgid "Active"
+msgstr "Activo"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_ids
+msgid "Activities"
+msgstr "Actividades"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_exception_decoration
+#, fuzzy
+msgid "Activity Exception Decoration"
+msgstr "Decoración de excepción de actividad"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_state
+#, fuzzy
+msgid "Activity State"
+msgstr "Estado de Actividad"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__sale_activity_note
+#, fuzzy
+msgid "Activity Summary"
+msgstr "Resumen Actividad"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_type_icon
+#, fuzzy
+msgid "Activity Type Icon"
+msgstr "Icono de tipo de actividad"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__sale_activity_user_id
+#, fuzzy
+msgid "Activity User"
+msgstr "Actividad Usuario"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__sale_activity_type_id
+#, fuzzy
+msgid "Activity will be automatically scheduled on payment due date, improving collection process."
+msgstr "La actividad se programará automáticamente en la fecha de vencimiento del pago, mejorando el proceso de cobro."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__alias_name
+#, fuzzy
+msgid "Alias Name"
+msgstr "Seudónimo"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__alias_domain
+#, fuzzy
+msgid "Alias domain"
+msgstr "Dominio del seudónimo"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__account_control_ids
+msgid "Allowed accounts"
+msgstr "Cuentas permitidas"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, python-format
+msgid "Already imported items"
+msgstr "El elemento ya está importado"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_attachment_count
+msgid "Attachment Count"
+msgstr "Cantidad de adjuntos"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__available_payment_method_ids
+msgid "Available Payment Method"
+msgstr "Métodos de pagos disponible"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__bank_id
+#, python-format
+msgid "Bank"
+msgstr "Banco"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__bank_account_id
+msgid "Bank Account"
+msgstr "Cuenta de banco"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__bank_statements_source
+#, fuzzy
+msgid "Bank Feeds"
+msgstr "Conexiones Bancarias"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_journal_creation_view
+msgid "Bank Journal Name"
+msgstr "Nombre del diario"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model,name:om_account_bank_statement_import.model_account_bank_statement_line
+msgid "Bank Statement Line"
+msgstr "Línea de extracto bancario"
+
+#. module: om_account_bank_statement_import
+#: model:ir.actions.act_window,name:om_account_bank_statement_import.action_bank_statement_line
+#, fuzzy
+msgid "Bank Statement Lines"
+msgstr "Líneas de extracto bancario"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model,name:om_account_bank_statement_import.model_account_setup_bank_manual_config
+msgid "Bank setup manual config"
+msgstr "Configuración manual de datos bancarios"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__suspense_account_id
+msgid ""
+"Bank statements transactions will be posted on the suspense account until the final reconciliation allowing finding the "
+"right account."
+msgstr ""
+"Las transacciones de los extractos bancarios se contabilizarán en la cuenta transitoria hasta la conciliación final que "
+"permita encontrar la cuenta correcta."
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_journal_creation_view
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_view
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, python-format
+msgid "Cannot find in which journal import this statement. Please manually select a journal."
+msgstr "No se puede encontrar en qué diario está el extracto a importar. Seleccione manualmente el diario."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__refund_sequence
+msgid "Check this box if you don't want to share the same sequence for invoices and credit notes made from this journal"
+msgstr ""
+"Marque esta casilla si no desea compartir la misma secuencia para facturas y notas de crédito realizadas a partir de este "
+"diario"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__payment_sequence
+#, fuzzy
+msgid "Check this box if you don't want to share the same sequence on payments and bank transactions posted on this journal"
+msgstr ""
+"Marque esta casilla si no desea compartir la misma secuencia en los pagos y transacciones bancarias publicadas en este "
+"diario"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__color
+#, fuzzy
+msgid "Color Index"
+msgstr "Índice de Colores"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__invoice_reference_model
+#, fuzzy
+msgid "Communication Standard"
+msgstr "Estándar de Comunicación"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__invoice_reference_type
+#, fuzzy
+msgid "Communication Type"
+msgstr "Tipo de comunicación"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__company_id
+#, fuzzy
+msgid "Company"
+msgstr "Compañía"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__company_id
+#, fuzzy
+msgid "Company related to this journal"
+msgstr "Empresa relacionada con este diario"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__compatible_edi_ids
+#, fuzzy
+msgid "Compatible Edi"
+msgstr "Compatible Edi"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, fuzzy, python-format
+msgid ""
+"Could not make sense of the given file.\n"
+"Did you install the module to support this type of file ?"
+msgstr ""
+"No se pudo dar sentido al archivo dado.\n"
+"¿Instaló el módulo para admitir este tipo de archivo?"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__country_code
+#, fuzzy
+msgid "Country Code"
+msgstr "Código de país"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import__create_uid
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__create_uid
+#, fuzzy
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import__create_date
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__create_date
+#, fuzzy
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__currency_id
+#, fuzzy
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__current_statement_balance
+#, fuzzy
+msgid "Current Statement Balance"
+msgstr "Saldo del estado de cuenta actual"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__refund_sequence
+#, fuzzy
+msgid "Dedicated Credit Note Sequence"
+msgstr "Secuencia de notas de crédito dedicada"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__payment_sequence
+#, fuzzy
+msgid "Dedicated Payment Sequence"
+msgstr "Secuencia de pago dedicada"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__default_account_id
+msgid "Default Account"
+msgstr "Cuenta por defecto"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__default_account_type
+msgid "Default Account Type"
+msgstr "Tipo de cuenta por defecto"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__bank_statements_source
+msgid "Defines how the bank statements will be registered"
+msgstr "Define cómo se registrarán los extractos bancarios"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import__display_name
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__display_name
+#, fuzzy
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__compatible_edi_ids
+#, fuzzy
+msgid "EDI format that support moves in this journal"
+msgstr "Formato EDI que soporta movimientos en esta revista"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__edi_format_ids
+#, fuzzy
+msgid "Electronic invoicing"
+msgstr "Facturación electrónica"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__alias_id
+#, fuzzy
+msgid "Email Alias"
+msgstr "Seudónimo de correo electrónico"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__entries_count
+#, fuzzy
+msgid "Entries Count"
+msgstr "Número de asientos"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import__attachment_ids
+#, fuzzy
+msgid "Files"
+msgstr "Archivos"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_follower_ids
+#, fuzzy
+msgid "Followers"
+msgstr "Seguidores"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_partner_ids
+#, fuzzy
+msgid "Followers (Partners)"
+msgstr "Seguidores (Socios)"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_type_icon
+#, fuzzy
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr "Icono de Fotn awesome, por ejemplo fa-tasks"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import__attachment_ids
+msgid "Get you bank statements in electronic format from your bank and select them here."
+msgstr "Obtén tus extractos bancarios en formato electrónico de tu banco y selecciónalos aquí."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__has_message
+#, fuzzy
+msgid "Has Message"
+msgstr "Tiene mensaje"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__has_sequence_holes
+#, fuzzy
+msgid "Has Sequence Holes"
+msgstr "Tiene orificios de secuencia"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__has_statement_lines
+#, fuzzy
+msgid "Has Statement Lines"
+msgstr "Tiene líneas de instrucción"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import__id
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__id
+#, fuzzy
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_exception_icon
+#, fuzzy
+msgid "Icon"
+msgstr "Icono"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_exception_icon
+#, fuzzy
+msgid "Icon to indicate an exception activity."
+msgstr "Icono para indicar una actividad de excepción."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_needaction
+#, fuzzy
+msgid "If checked, new messages require your attention."
+msgstr "Si está marcado, los nuevos mensajes requieren su atención."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_has_error
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_has_sms_error
+#, fuzzy
+msgid "If checked, some messages have a delivery error."
+msgstr "Si está marcada, algunos mensajes tienen un error de entrega."
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, fuzzy, python-format
+msgid "If it contains transactions for more than one account, it must be imported on each of them."
+msgstr "Si contiene transacciones para más de una cuenta, debe importarse en cada una de ellas."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__restrict_mode_hash_table
+#, fuzzy
+msgid "If ticked, the accounting entry or invoice receives a hash as soon as it is posted and cannot be modified anymore."
+msgstr ""
+"Si se marca, el asiento contable o la factura recibe un hash tan pronto como se contabiliza y ya no se puede modificar."
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_journal.py:0
+#, python-format
+msgid "Import"
+msgstr "Importar"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model,name:om_account_bank_statement_import.model_account_bank_statement_import
+msgid "Import Bank Statement"
+msgstr "Importar extracto bancario"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_line__unique_import_id
+#, fuzzy
+msgid "Import ID"
+msgstr "ID de importación"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.journal_dashboard_view_inherit
+msgid "Import Statement"
+msgstr "Importar extracto"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__inbound_payment_method_line_ids
+#, fuzzy
+msgid "Inbound Payment Methods"
+msgstr "Métodos de pago entrante"
+
+#. module: om_account_bank_statement_import
+#: model:ir.actions.act_window,name:om_account_bank_statement_import.install_more_import_formats_action
+#, fuzzy
+msgid "Install Import Format"
+msgstr "Instalar formato de importación"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, python-format
+msgid "Invalid file!"
+msgstr "Archivo incorrecto!"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_is_follower
+#, fuzzy
+msgid "Is Follower"
+msgstr "Es seguidor"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__alias_name
+#, fuzzy
+msgid "It creates draft invoices and bills by sending an email."
+msgstr "Crea borradores de facturas enviando un correo electrónico."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model,name:om_account_bank_statement_import.model_account_journal
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__journal_id
+msgid "Journal"
+msgstr "Diario"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_journal_creation_view
+#, fuzzy, python-format
+msgid "Journal Creation"
+msgstr "Creación de revistas"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model,name:om_account_bank_statement_import.model_account_bank_statement_import_journal_creation
+msgid "Journal Creation on Bank Statement Import"
+msgstr "Creación de diario en la importación de extractos bancarios"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__journal_group_ids
+#, fuzzy
+msgid "Journal Groups"
+msgstr "Grupos de Diarios"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__name
+msgid "Journal Name"
+msgstr "Nombre del diario"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__json_activity_data
+#, fuzzy
+msgid "Json Activity Data"
+msgstr "Datos de actividad de Json"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_journal_creation_view
+#, fuzzy
+msgid ""
+"Just click OK to create the account/journal and finish the upload. If this was a mistake, hit cancel to abort the upload."
+msgstr ""
+"Simplemente haga clic en Aceptar para crear la cuenta / diario y finalizar la carga. Si esto fue un error, presione "
+"cancelar para abortar la carga."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__kanban_dashboard
+#, fuzzy
+msgid "Kanban Dashboard"
+msgstr "Tablero Kanban"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__kanban_dashboard_graph
+#, fuzzy
+msgid "Kanban Dashboard Graph"
+msgstr "Gráfico de Tablero Kanban"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import____last_update
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation____last_update
+#, fuzzy
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import__write_uid
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__write_uid
+#, fuzzy
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import__write_date
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__write_date
+#, fuzzy
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__sale_activity_user_id
+#, fuzzy
+msgid "Leave empty to assign the Salesperson of the invoice."
+msgstr "Deje vacío para asignar al comercial de la factura."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__restrict_mode_hash_table
+#, fuzzy
+msgid "Lock Posted Entries with Hash"
+msgstr "Bloquear asientos validados con hash"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__loss_account_id
+#, fuzzy
+msgid "Loss Account"
+msgstr "Cuenta de pérdidas"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_main_attachment_id
+#, fuzzy
+msgid "Main Attachment"
+msgstr "Archivo adjunto principal"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__inbound_payment_method_line_ids
+#, fuzzy
+msgid ""
+"Manual: Get paid by any method outside of Odoo.\n"
+"Payment Providers: Each payment provider has its own Payment Method. Request a transaction on/to a card thanks to a "
+"payment token saved by the partner when buying or subscribing online.\n"
+"Batch Deposit: Collect several customer checks at once generating and submitting a batch deposit to your bank. Module "
+"account_batch_payment is necessary.\n"
+"SEPA Direct Debit: Get paid in the SEPA zone thanks to a mandate your partner will have granted to you. Module "
+"account_sepa is necessary.\n"
+msgstr ""
+"Manual: Recibe pagos por cualquier método fuera de Odoo.\n"
+"Proveedores de pago: Cada proveedor de pago tiene su propio método de pago. Solicite una transacción en / hacia una "
+"tarjeta gracias a un token de pago guardado por el socio al comprar o suscribirse en línea.\n"
+"Depósito por lotes: Cobra varios cheques de clientes a la vez generando y enviando un depósito por lotes a tu banco. El "
+"módulo account_batch_payment es necesario.\n"
+"Adeudo directo SEPA: Recibe pagos en la zona SEPA gracias a un mandato que tu pareja te habrá otorgado. El módulo "
+"account_sepa es necesario.\n"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__outbound_payment_method_line_ids
+#, fuzzy
+msgid ""
+"Manual: Pay by any method outside of Odoo.\n"
+"Check: Pay bills by check and print it from Odoo.\n"
+"SEPA Credit Transfer: Pay in the SEPA zone by submitting a SEPA Credit Transfer file to your bank. Module account_sepa is "
+"necessary.\n"
+msgstr ""
+"Manual: obtenga su pago con cualquier método fuera de Odoo.\n"
+"Cheque: pague facturas con cheques e imprímalos desde Odoo.\n"
+"Transferencia de crédito SEPA: envíe un archiva de transferencia de crédito SEPA a su banco y así pague en la zona SEPA. "
+"Se necesita el módulo account_sepa.\n"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_has_error
+#, fuzzy
+msgid "Message Delivery error"
+msgstr "Error de entrega de mensajes"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_ids
+#, fuzzy
+msgid "Messages"
+msgstr "Mensajes"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__my_activity_date_deadline
+#, fuzzy
+msgid "My Activity Deadline"
+msgstr "Fecha límite de mi actividad"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_date_deadline
+#, fuzzy
+msgid "Next Activity Deadline"
+msgstr "Fecha límite de la próxima actividad"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_summary
+#, fuzzy
+msgid "Next Activity Summary"
+msgstr "Resumen de la siguiente actividad"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_type_id
+#, fuzzy
+msgid "Next Activity Type"
+msgstr "Siguiente tipo de actividad"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, python-format
+msgid "No currency found matching '%s'."
+msgstr "No se encontró ninguna moneda que coincida '%s'."
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.view_bank_statement_line_form
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.view_bank_statement_line_search
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.view_bank_statement_line_tree
+#, fuzzy
+msgid "Notes"
+msgstr "Notas"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_needaction_counter
+#, fuzzy
+msgid "Number of Actions"
+msgstr "Número de acciones"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_has_error_counter
+#, fuzzy
+msgid "Number of errors"
+msgstr "Número de errores"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_needaction_counter
+#, fuzzy
+msgid "Number of messages which requires an action"
+msgstr "Número de mensajes que requieren una acción"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_has_error_counter
+#, fuzzy
+msgid "Number of messages with delivery error"
+msgstr "Número de mensajes con error de entrega"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_journal_creation_view
+#, fuzzy
+msgid "OK"
+msgstr "Vale"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.actions.act_window,help:om_account_bank_statement_import.action_bank_statement_line
+#, fuzzy
+msgid ""
+"Odoo allows you to reconcile a statement line directly with\n"
+"                the related sale or purchase invoice(s)."
+msgstr ""
+"Odoo te permite conciliar una línea del extracto directamente con\n"
+"                la(s) factura(s) de compra o venta relacionada(s)."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__outbound_payment_method_line_ids
+#, fuzzy
+msgid "Outbound Payment Methods"
+msgstr "Métodos de pago salientes"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, fuzzy, python-format
+msgid ""
+"Please upload in specified format ! \n"
+"date, payment reference, reference, partner, amount, currency !"
+msgstr ""
+"¡Por favor, cargue en el formato especificado! \n"
+"fecha, referencia de pago, referencia, socio, importe, divisa !"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__profit_account_id
+#, fuzzy
+msgid "Profit Account"
+msgstr "Cuenta de ganancias"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_user_id
+#, fuzzy
+msgid "Responsible User"
+msgstr "Usuario responsable"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__message_has_sms_error
+#, fuzzy
+msgid "SMS Delivery error"
+msgstr "Error de entrega de SMS"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__sale_activity_type_id
+#, fuzzy
+msgid "Schedule Activity"
+msgstr "Planificar actividad"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.view_bank_statement_line_search
+#, fuzzy
+msgid "Search Bank Statements Line"
+msgstr "Buscar líneas de extractos bancarios"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__secure_sequence_id
+#, fuzzy
+msgid "Secure Sequence"
+msgstr "Secuencia de seguridad"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__type
+#, fuzzy
+msgid ""
+"Select 'Sale' for customer invoices journals.\n"
+"Select 'Purchase' for vendor bills journals.\n"
+"Select 'Cash' or 'Bank' for journals that are used in customer or vendor payments.\n"
+"Select 'General' for miscellaneous operations journals."
+msgstr ""
+"Selecciona 'Ventas' para diarios de facturas de cliente.\n"
+"Selecciona 'Compras' para diarios de facturas de proveedor.\n"
+"Selecciona 'Caja' o 'Banco' para diarios que se usan para pagos de clientes y proveedores. \n"
+"Selecciona 'General' para diarios que contienen operaciones varias."
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_view
+msgid "Select Files"
+msgstr "Seleccione un archivo"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__selected_payment_method_codes
+#, fuzzy
+msgid "Selected Payment Method Codes"
+msgstr "Códigos de métodos de pago seleccionados"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__edi_format_ids
+#, fuzzy
+msgid "Send XML/EDI invoices"
+msgstr "Enviar facturas XML/EDI"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__alias_id
+#, fuzzy
+msgid ""
+"Send one separate email for each invoice.\n"
+"\n"
+"Any file extension will be accepted.\n"
+"\n"
+"Only PDF and XML files will be interpreted by Odoo"
+msgstr ""
+"Envía un correo electrónico por separado para cada factura.\n"
+"\n"
+"Se aceptará cualquier extensión de archivo.\n"
+"\n"
+"Odoo solo interpretará archivos PDF y XML"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__sequence_override_regex
+#, fuzzy
+msgid "Sequence Override Regex"
+msgstr "Regex de anulación de secuencia"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__secure_sequence_id
+#, fuzzy
+msgid "Sequence to use to ensure the securisation of data"
+msgstr "La secuencia se utiliza para garantizar la titulización de los datos"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__active
+#, fuzzy
+msgid "Set active to false to hide the Journal without removing it."
+msgstr "Establece activo a falso para ocultar el diario sin eliminarlo."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__code
+#, fuzzy
+msgid "Short Code"
+msgstr "Código corto"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__code
+#, fuzzy
+msgid "Shorter name used for display. The journal entries of this journal will also be named using this prefix by default."
+msgstr ""
+"Nombre más corto utilizado para mostrar. Los asientos de este diario también se nombrarán con este prefijo de forma "
+"predeterminada."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__show_on_dashboard
+#, fuzzy
+msgid "Show journal on dashboard"
+msgstr "Mostrar diario en el tablero"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.view_bank_statement_line_search
+#, fuzzy
+msgid "Statement"
+msgstr "Extracto"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.view_bank_statement_line_form
+#, fuzzy
+msgid "Statement Line"
+msgstr "Línea de extracto"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.view_bank_statement_line_tree
+#, fuzzy
+msgid "Statement lines"
+msgstr "Líneas de extracto"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_journal.py:0
+#, fuzzy, python-format
+msgid "Statements"
+msgstr "Extractos"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_state
+#, fuzzy
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+"Estado basado en actividades\n"
+"Atrasado: la fecha de vencimiento ya pasó\n"
+"Hoy: la fecha de la actividad es hoy\n"
+"Planificado: Actividades futuras."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__suspense_account_id
+#, fuzzy
+msgid "Suspense Account"
+msgstr "Cuenta transitoria"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__sequence_override_regex
+#, fuzzy
+msgid ""
+"Technical field used to enforce complex sequence composition that the system would normally misunderstand.\n"
+"This is a regex that can include all the following capture groups: prefix1, year, prefix2, month, prefix3, seq, suffix.\n"
+"The prefix* groups are the separators between the year, month and the actual increasing sequence number (seq).\n"
+"e.g: ^(?P<prefix1>.*?)(?P<year>\\d{4})(?P<prefix2>\\D*?)(?P<month>\\d{2})(?P<prefix3>\\D+?)(?P<seq>\\d+)(?P<suffix>\\D*?)$"
+msgstr ""
+"Campo técnico utilizado para imponer una composición de secuencia compleja que el sistema normalmente malinterpretaría.\n"
+"Esta es una expresión regular que puede incluir todos los siguientes grupos de captura: prefijo1, año, prefijo2, mes, "
+"prefijo3, seq, sufijo.\n"
+"Los grupos de prefijo * son los separadores entre el año, el mes y el número de secuencia creciente real (seq).\n"
+"por ejemplo: ^(?P<prefix1>.*?)(?P<year>\\d{4})(?P<prefix2>\\D*?)(?P<month>\\d{2})(?P<prefix3>\\D+?)(?P<seq>\\d+)(?"
+"P<suffix>\\D*?)$"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__country_code
+#, fuzzy
+msgid ""
+"The ISO country code in two chars. \n"
+"You can use this field for quick search."
+msgstr ""
+"EL código ISO del país en dos caracteres.\n"
+"Puedes utilizar este campo para una búsqueda rápida."
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_journal_creation_view
+#, fuzzy
+msgid ""
+"The account of the statement you are uploading is not yet recorded in Odoo. In order to proceed with the upload, you need "
+"to create a bank journal for this account."
+msgstr ""
+"La cuenta del estado de cuenta que está cargando aún no está registrada en Odoo. Para continuar con la carga, debe crear "
+"un diario bancario para esta cuenta."
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, python-format
+msgid "The account of this statement (%s) is not the same as the journal (%s)."
+msgstr "La cuenta del extracto (%s) no es la misma que la del diario (%s)."
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, python-format
+msgid "The currency of the bank statement (%s) is not the same as the currency of the journal (%s)."
+msgstr "La moneda del extracto bancario (%s) no es la misma que la moneda del diario (%s)."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__currency_id
+msgid "The currency used to enter statement"
+msgstr "La moneda utilizada para ingresar el extracto bancario"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, python-format
+msgid "This file doesn't contain any statement for account %s."
+msgstr "Este archivo %s no contiene ningún extracto de cuenta."
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, python-format
+msgid "This file doesn't contain any transaction for account %s."
+msgstr "Este archivo %s no contiene ninguna operación de cuenta."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__type
+msgid "Type"
+msgstr "Tipo"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__activity_exception_decoration
+#, fuzzy
+msgid "Type of the exception activity on record."
+msgstr "Tipo de actividad de excepción registrada."
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, python-format
+msgid "Unsupported File Type"
+msgstr "Tipo de archivo no soportado"
+
+#. module: om_account_bank_statement_import
+#: model:ir.actions.act_window,name:om_account_bank_statement_import.action_om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_view
+msgid "Upload"
+msgstr "Subir"
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_view
+#, fuzzy
+msgid "Upload Your Statements"
+msgstr "Sube tus estados de cuenta"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__sequence
+#, fuzzy
+msgid "Used to order Journals in the dashboard view"
+msgstr "Utilizado para ordenar los diarios en la vista de tablero"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__loss_account_id
+#, fuzzy
+msgid "Used to register a loss when the ending balance of a cash register differs from what the system computes"
+msgstr ""
+"Utilizado para registrar una pérdida cuando el saldo final de un registro de caja difiere de lo que el sistema calcula"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__profit_account_id
+#, fuzzy
+msgid "Used to register a profit when the ending balance of a cash register differs from what the system computes"
+msgstr ""
+"Utilizado para registrar una ganancia cuando el saldo final de un registro de caja difiere de lo que el sistema calcula"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,field_description:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__website_message_ids
+#, fuzzy
+msgid "Website Messages"
+msgstr "Mensajes del sitio web"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__website_message_ids
+#, fuzzy
+msgid "Website communication history"
+msgstr "Historial de comunicación del sitio web"
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__show_on_dashboard
+#, fuzzy
+msgid "Whether this journal should be displayed on the dashboard or not"
+msgstr "Si este diario debe mostrarse en el tablero o no"
+
+#. module: om_account_bank_statement_import
+#. odoo-python
+#: code:addons/om_account_bank_statement_import/models/account_bank_statement_import.py:0
+#, python-format
+msgid "You already have imported that file."
+msgstr "Ya has importado ese archivo."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__invoice_reference_model
+msgid "You can choose different models for each type of reference. The default one is the Odoo reference."
+msgstr "Puede elegir diferentes modelos para cada tipo de referencia. Por defecto es la referencia de Odoo."
+
+#. module: om_account_bank_statement_import
+#: model:ir.model.fields,help:om_account_bank_statement_import.field_account_bank_statement_import_journal_creation__invoice_reference_type
+#, fuzzy
+msgid ""
+"You can set here the default communication that will appear on customer invoices, once validated, to help the customer to "
+"refer to that particular invoice when making the payment."
+msgstr ""
+"Puedes establecer aquí la comunicación predeterminada que aparecerá en las facturas del cliente, una vez validada, para "
+"ayudar al cliente a consultar esa factura en particular al realizar el pago."
+
+#. module: om_account_bank_statement_import
+#: model_terms:ir.ui.view,arch_db:om_account_bank_statement_import.om_account_bank_statement_import_view
+#, fuzzy
+msgid "You can upload your statement using:"
+msgstr "Puede cargar su estado de cuenta usando:"

--- a/om_account_budget/i18n/es_CR.po
+++ b/om_account_budget/i18n/es_CR.po
@@ -1,0 +1,582 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_account_budget
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 20:50+0000\n"
+"PO-Revision-Date: 2023-07-08 14:51-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_account_budget
+#. odoo-python
+#: code:addons/om_account_budget/models/account_budget.py:0
+#, fuzzy, python-format
+msgid "\"End Date\" of the budget line should be included in the Period of the budget"
+msgstr ""
+"La \"Fecha de finalización\" de la línea presupuestaria debe incluirse en el período "
+"del presupuesto"
+
+#. module: om_account_budget
+#. odoo-python
+#: code:addons/om_account_budget/models/account_budget.py:0
+#, fuzzy, python-format
+msgid "\"Start Date\" of the budget line should be included in the Period of the budget"
+msgstr ""
+"La \"Fecha de inicio\" de la línea presupuestaria debe incluirse en el período del "
+"presupuesto"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_kanban
+#, fuzzy
+msgid "<i class=\"fa fa-clock-o\" role=\"img\" aria-label=\"Period\" title=\"Period\"/>"
+msgstr ""
+"<i class=\"fa fa-clock-o\" role=\"img\" aria-label=\"Period\" title=\"Period\"/>"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_budget_post__account_ids
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_budget_post_form
+#, fuzzy
+msgid "Accounts"
+msgstr "Cuentas"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__percentage
+#, fuzzy
+msgid "Achievement"
+msgstr "Logro"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_needaction
+#, fuzzy
+msgid "Action Needed"
+msgstr "Acción necesaria"
+
+#. module: om_account_budget
+#: model:ir.model.fields,help:om_account_budget.field_crossovered_budget_lines__practical_amount
+#, fuzzy
+msgid "Amount really earned/spent."
+msgstr "Cantidad realmente ganada/gastada."
+
+#. module: om_account_budget
+#: model:ir.model.fields,help:om_account_budget.field_crossovered_budget_lines__theoritical_amount
+#, fuzzy
+msgid "Amount you are supposed to have earned/spent at this date."
+msgstr "Cantidad que se supone que debe haber ganado / gastado en esta fecha."
+
+#. module: om_account_budget
+#: model:ir.model.fields,help:om_account_budget.field_crossovered_budget_lines__planned_amount
+#, fuzzy
+msgid ""
+"Amount you plan to earn/spend. Record a positive amount if it is a revenue and a "
+"negative amount if it is a cost."
+msgstr ""
+"Cantidad que planea ganar/gastar. Registre una cantidad positiva si es un ingreso y "
+"una cantidad negativa si es un costo."
+
+#. module: om_account_budget
+#: model:ir.model,name:om_account_budget.model_account_analytic_account
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__analytic_account_id
+msgid "Analytic Account"
+msgstr "Cuenta analítica"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__analytic_plan_id
+#, fuzzy
+msgid "Analytic Plan"
+msgstr "Plan analítico"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#, fuzzy
+msgid "Approve"
+msgstr "Aprobar"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_attachment_count
+#, fuzzy
+msgid "Attachment Count"
+msgstr "Recuento de archivos adjuntos"
+
+#. module: om_account_budget
+#: model:ir.model,name:om_account_budget.model_crossovered_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__crossovered_budget_id
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_tree
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_search
+#, fuzzy
+msgid "Budget"
+msgstr "Presupuesto"
+
+#. module: om_account_budget
+#: model:ir.actions.act_window,name:om_account_budget.act_account_analytic_account_cb_lines
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_account_analytic_account_form_inherit_budget
+#, fuzzy
+msgid "Budget Items"
+msgstr "Partidas presupuestarias"
+
+#. module: om_account_budget
+#: model:ir.model,name:om_account_budget.model_crossovered_budget_lines
+#, fuzzy
+msgid "Budget Line"
+msgstr "Línea de presupuesto"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_analytic_account__crossovered_budget_line
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__crossovered_budget_line
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_form
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_graph
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_pivot
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_search
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_tree
+#, fuzzy
+msgid "Budget Lines"
+msgstr "Líneas presupuestarias"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__name
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#, fuzzy
+msgid "Budget Name"
+msgstr "Nombre del presupuesto"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__crossovered_budget_state
+#, fuzzy
+msgid "Budget State"
+msgstr "Estado del presupuesto"
+
+#. module: om_account_budget
+#: model:ir.model,name:om_account_budget.model_account_budget_post
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__general_budget_id
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_budget_post_form
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_budget_post_search
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_budget_post_tree
+#, fuzzy
+msgid "Budgetary Position"
+msgstr "Situación Presupuestaria"
+
+#. module: om_account_budget
+#: model:ir.actions.act_window,name:om_account_budget.open_budget_post_form
+#: model:ir.ui.menu,name:om_account_budget.menu_budget_post_form
+#, fuzzy
+msgid "Budgetary Positions"
+msgstr "Situaciones presupuestarias"
+
+#. module: om_account_budget
+#: model:ir.actions.act_window,name:om_account_budget.act_crossovered_budget_view
+#: model:ir.ui.menu,name:om_account_budget.menu_act_crossovered_budget_view
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_search
+#, fuzzy
+msgid "Budgets"
+msgstr "Presupuestos"
+
+#. module: om_account_budget
+#: model:ir.actions.act_window,name:om_account_budget.act_crossovered_budget_lines_view
+#: model:ir.ui.menu,name:om_account_budget.menu_act_crossovered_budget_lines_view
+#, fuzzy
+msgid "Budgets Analysis"
+msgstr "Análisis de Presupuestos"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#, fuzzy
+msgid "Cancel Budget"
+msgstr "Cancelar presupuesto"
+
+#. module: om_account_budget
+#: model:ir.model.fields.selection,name:om_account_budget.selection__crossovered_budget__state__cancel
+#, fuzzy
+msgid "Cancelled"
+msgstr "Cancelado"
+
+#. module: om_account_budget
+#: model_terms:ir.actions.act_window,help:om_account_budget.act_crossovered_budget_view
+#, fuzzy
+msgid "Click to create a new budget."
+msgstr "Haga clic para crear un nuevo presupuesto."
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_budget_post__company_id
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__company_id
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__company_id
+#, fuzzy
+msgid "Company"
+msgstr "Compañía"
+
+#. module: om_account_budget
+#: model:ir.model.fields,help:om_account_budget.field_crossovered_budget_lines__percentage
+#, fuzzy
+msgid ""
+"Comparison between practical and theoretical amount. This measure tells you if you "
+"are below or over budget."
+msgstr ""
+"Comparación entre cantidad práctica y teórica. Esta medida le indica si está por "
+"debajo o por encima del presupuesto."
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#, fuzzy
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: om_account_budget
+#: model:ir.model.fields.selection,name:om_account_budget.selection__crossovered_budget__state__confirm
+#, fuzzy
+msgid "Confirmed"
+msgstr "Confirmado"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_budget_post__create_uid
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__create_uid
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__create_uid
+#, fuzzy
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_budget_post__create_date
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__create_date
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__create_date
+#, fuzzy
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__currency_id
+#, fuzzy
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_budget_post__display_name
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__display_name
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__display_name
+#, fuzzy
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: om_account_budget
+#: model:ir.model.fields.selection,name:om_account_budget.selection__crossovered_budget__state__done
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#, fuzzy
+msgid "Done"
+msgstr "Realizado"
+
+#. module: om_account_budget
+#: model:ir.model.fields.selection,name:om_account_budget.selection__crossovered_budget__state__draft
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_search
+#, fuzzy
+msgid "Draft"
+msgstr "Borrador"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_search
+#, fuzzy
+msgid "Draft Budgets"
+msgstr "Proyectos de presupuesto"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__date_to
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__date_to
+#, fuzzy
+msgid "End Date"
+msgstr "Fecha final"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#, fuzzy
+msgid "Entries..."
+msgstr "Asientos"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_follower_ids
+#, fuzzy
+msgid "Followers"
+msgstr "Seguidores"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_partner_ids
+#, fuzzy
+msgid "Followers (Partners)"
+msgstr "Seguidores (Socios)"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_search
+#, fuzzy
+msgid "Group By"
+msgstr "Agrupar por"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__has_message
+#, fuzzy
+msgid "Has Message"
+msgstr "Tiene mensaje"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_budget_post__id
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__id
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__id
+#, fuzzy
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: om_account_budget
+#: model:ir.model.fields,help:om_account_budget.field_crossovered_budget__message_needaction
+#, fuzzy
+msgid "If checked, new messages require your attention."
+msgstr "Si está marcado, los nuevos mensajes requieren su atención."
+
+#. module: om_account_budget
+#: model:ir.model.fields,help:om_account_budget.field_crossovered_budget__message_has_error
+#: model:ir.model.fields,help:om_account_budget.field_crossovered_budget__message_has_sms_error
+#, fuzzy
+msgid "If checked, some messages have a delivery error."
+msgstr "Si está marcada, algunos mensajes tienen un error de entrega."
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__is_above_budget
+#, fuzzy
+msgid "Is Above Budget"
+msgstr "Está por encima del presupuesto"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_is_follower
+#, fuzzy
+msgid "Is Follower"
+msgstr "Es seguidor"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_budget_post____last_update
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget____last_update
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines____last_update
+#, fuzzy
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_budget_post__write_uid
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__write_uid
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__write_uid
+#, fuzzy
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_budget_post__write_date
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__write_date
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__write_date
+#, fuzzy
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_main_attachment_id
+#, fuzzy
+msgid "Main Attachment"
+msgstr "Archivo adjunto principal"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_has_error
+#, fuzzy
+msgid "Message Delivery error"
+msgstr "Error de entrega de mensajes"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_ids
+#, fuzzy
+msgid "Messages"
+msgstr "Mensajes"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_account_budget_post__name
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__name
+#, fuzzy
+msgid "Name"
+msgstr "Nombre"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_search
+#, fuzzy
+msgid "Not Cancelled"
+msgstr "Cancelado"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_needaction_counter
+#, fuzzy
+msgid "Number of Actions"
+msgstr "Número de acciones"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_has_error_counter
+#, fuzzy
+msgid "Number of errors"
+msgstr "Número de errores"
+
+#. module: om_account_budget
+#: model:ir.model.fields,help:om_account_budget.field_crossovered_budget__message_needaction_counter
+#, fuzzy
+msgid "Number of messages which requires an action"
+msgstr "Número de mensajes que requieren una acción"
+
+#. module: om_account_budget
+#: model:ir.model.fields,help:om_account_budget.field_crossovered_budget__message_has_error_counter
+#, fuzzy
+msgid "Number of messages with delivery error"
+msgstr "Número de mensajes con error de entrega"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__paid_date
+#, fuzzy
+msgid "Paid Date"
+msgstr "Fecha de pago"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#, fuzzy
+msgid "Period"
+msgstr "Periodo"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__planned_amount
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#, fuzzy
+msgid "Planned Amount"
+msgstr "Cantidad planificada"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_graph
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_pivot
+#, fuzzy
+msgid "Planned amount"
+msgstr "Importe previsto"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__practical_amount
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_account_analytic_account_form_inherit_budget
+#, fuzzy
+msgid "Practical Amount"
+msgstr "Cantidad práctica"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_graph
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_pivot
+#, fuzzy
+msgid "Practical amount"
+msgstr "Cantidad práctica"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#, fuzzy
+msgid "Reset to Draft"
+msgstr "Restablecer a borrador"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__user_id
+#, fuzzy
+msgid "Responsible"
+msgstr "Responsable"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__message_has_sms_error
+#, fuzzy
+msgid "SMS Delivery error"
+msgstr "Error de entrega de SMS"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__date_from
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__date_from
+#, fuzzy
+msgid "Start Date"
+msgstr "Fecha inicial"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__state
+#, fuzzy
+msgid "Status"
+msgstr "Estado"
+
+#. module: om_account_budget
+#. odoo-python
+#: code:addons/om_account_budget/models/account_budget.py:0
+#, fuzzy, python-format
+msgid "The budget must have at least one account."
+msgstr "El presupuesto debe tener al menos una cuenta."
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget_lines__theoritical_amount
+#: model_terms:ir.ui.view,arch_db:om_account_budget.crossovered_budget_view_form
+#, fuzzy
+msgid "Theoretical Amount"
+msgstr "Importe teórico"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_account_analytic_account_form_inherit_budget
+#, fuzzy
+msgid "Theoritical Amount"
+msgstr "Cantidad teórica"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_graph
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_line_pivot
+#, fuzzy
+msgid "Theoritical amount"
+msgstr "Cantidad teórica"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_search
+#, fuzzy
+msgid "To Approve"
+msgstr "Por aprobar"
+
+#. module: om_account_budget
+#: model_terms:ir.ui.view,arch_db:om_account_budget.view_crossovered_budget_search
+#, fuzzy
+msgid "To Approve Budgets"
+msgstr "Para aprobar presupuestos"
+
+#. module: om_account_budget
+#: model_terms:ir.actions.act_window,help:om_account_budget.act_crossovered_budget_view
+#, fuzzy
+msgid "Use budgets to compare actual with expected revenues and costs"
+msgstr ""
+"Utiliza los presupuestos para comparar los ingresos y costos reales con los esperados."
+
+#. module: om_account_budget
+#: model:ir.model.fields.selection,name:om_account_budget.selection__crossovered_budget__state__validate
+#, fuzzy
+msgid "Validated"
+msgstr "Validado"
+
+#. module: om_account_budget
+#: model:ir.model.fields,field_description:om_account_budget.field_crossovered_budget__website_message_ids
+#, fuzzy
+msgid "Website Messages"
+msgstr "Mensajes del sitio web"
+
+#. module: om_account_budget
+#: model:ir.model.fields,help:om_account_budget.field_crossovered_budget__website_message_ids
+#, fuzzy
+msgid "Website communication history"
+msgstr "Historial de comunicación del sitio web"
+
+#. module: om_account_budget
+#. odoo-python
+#: code:addons/om_account_budget/models/account_budget.py:0
+#, fuzzy, python-format
+msgid ""
+"You have to enter at least a budgetary position or analytic account on a budget line."
+msgstr ""
+"Debe introducir al menos una situación presupuestaria o una cuenta analítica en una "
+"línea presupuestaria."

--- a/om_account_daily_reports/i18n/es_CR.po
+++ b/om_account_daily_reports/i18n/es_CR.po
@@ -1,0 +1,428 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_account_daily_reports
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 20:51+0000\n"
+"PO-Revision-Date: 2023-07-08 14:52-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "<strong>End Date:</strong>"
+msgstr "<strong>Fecha de Finalización:</strong>"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "<strong>Journals:</strong>"
+msgstr "<strong>Diarios:</strong>"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#, fuzzy
+msgid "<strong>Sorted By:</strong>"
+msgstr "<strong>Ordenado Por:</strong>"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "<strong>Start Date:</strong>"
+msgstr "<strong>Fecha de Inicio:</strong>"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "<strong>Target Moves:</strong>"
+msgstr "<strong>Movimientos señalados:</strong>"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#, fuzzy
+msgid "Account Bank Book"
+msgstr "Diario de Bancos"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#, fuzzy
+msgid "Account Cash Book"
+msgstr "Diario de Efectivo"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Account Day Book"
+msgstr "Diario"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__account_ids
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__account_ids
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__account_ids
+#, fuzzy
+msgid "Accounts"
+msgstr "Cuentas"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_bankbook_report__display_account__all
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_cashbook_report__display_account__all
+#, fuzzy
+msgid "All"
+msgstr "Todo"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_bankbook_report__target_move__all
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_cashbook_report__target_move__all
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_daybook_report__target_move__all
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "All Entries"
+msgstr "Todos los asientos"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Balance"
+msgstr "Saldo"
+
+#. module: om_account_daily_reports
+#: model:ir.actions.act_window,name:om_account_daily_reports.action_account_bankbook_menu
+#: model:ir.actions.report,name:om_account_daily_reports.action_report_bank_book
+#: model:ir.model,name:om_account_daily_reports.model_report_om_account_daily_reports_report_bankbook
+#: model:ir.ui.menu,name:om_account_daily_reports.menu_bankbook
+#, fuzzy
+msgid "Bank Book"
+msgstr "Libro Banco"
+
+#. module: om_account_daily_reports
+#: model:ir.model,name:om_account_daily_reports.model_account_bankbook_report
+#, fuzzy
+msgid "Bank Book Report"
+msgstr "Informe del Libro Bancario"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.account_report_bankbook_view
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.account_report_cashbook_view
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.account_report_daybook_view
+#, fuzzy
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: om_account_daily_reports
+#: model:ir.actions.act_window,name:om_account_daily_reports.action_account_cashbook_menu
+#: model:ir.actions.report,name:om_account_daily_reports.action_report_cash_book
+#: model:ir.model,name:om_account_daily_reports.model_report_om_account_daily_reports_report_cashbook
+#: model:ir.ui.menu,name:om_account_daily_reports.menu_cashbook
+#, fuzzy
+msgid "Cash Book"
+msgstr "Libro Efectivo"
+
+#. module: om_account_daily_reports
+#: model:ir.model,name:om_account_daily_reports.model_account_cashbook_report
+#, fuzzy
+msgid "Cash Book Report"
+msgstr "Informe del libro de Efectivo"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__create_uid
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__create_uid
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__create_uid
+#, fuzzy
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__create_date
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__create_date
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__create_date
+#, fuzzy
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Credit"
+msgstr "Crédito"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: om_account_daily_reports
+#: model:ir.ui.menu,name:om_account_daily_reports.menu_finance_daily_reports
+#, fuzzy
+msgid "Daily Reports"
+msgstr "Reportes Diario"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_bankbook_report__sortby__sort_date
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_cashbook_report__sortby__sort_date
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Date"
+msgstr "Fecha"
+
+#. module: om_account_daily_reports
+#: model:ir.actions.act_window,name:om_account_daily_reports.action_account_daybook_menu
+#: model:ir.actions.report,name:om_account_daily_reports.action_report_day_book
+#: model:ir.model,name:om_account_daily_reports.model_report_om_account_daily_reports_report_daybook
+#: model:ir.ui.menu,name:om_account_daily_reports.menu_daybook
+#, fuzzy
+msgid "Day Book"
+msgstr "Diario"
+
+#. module: om_account_daily_reports
+#: model:ir.model,name:om_account_daily_reports.model_account_daybook_report
+#, fuzzy
+msgid "Day Book Report"
+msgstr "Informe del Libro Diario"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Debit"
+msgstr "Débito"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__display_account
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__display_account
+#, fuzzy
+msgid "Display Accounts"
+msgstr "Mostrar Cuentas"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__display_name
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__display_name
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__display_name
+#, fuzzy
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__date_to
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__date_to
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__date_to
+#, fuzzy
+msgid "End Date"
+msgstr "Fecha final"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Entry Label"
+msgstr "Nivel Básico"
+
+#. module: om_account_daily_reports
+#. odoo-python
+#: code:addons/om_account_daily_reports/report/report_bankbook.py:0
+#: code:addons/om_account_daily_reports/report/report_cashbook.py:0
+#: code:addons/om_account_daily_reports/report/report_daybook.py:0
+#, fuzzy, python-format
+msgid "Form content is missing, this report cannot be printed."
+msgstr ""
+"Falta el contenido del formulario, este informe no se puede imprimir."
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__id
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__id
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__id
+#, fuzzy
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,help:om_account_daily_reports.field_account_bankbook_report__initial_balance
+#: model:ir.model.fields,help:om_account_daily_reports.field_account_cashbook_report__initial_balance
+#, fuzzy
+msgid ""
+"If you selected date, this field allow you to add a row to display the "
+"amount of debit/credit/balance that precedes the filter you've set."
+msgstr ""
+"Si seleccionó la fecha, este campo le permite agregar una fila para "
+"mostrar la cantidad de débito / crédito / saldo que precede al filtro "
+"que estableció."
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__initial_balance
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__initial_balance
+#, fuzzy
+msgid "Include Initial Balances"
+msgstr "Incluir Saldos Iniciales"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "JRNL"
+msgstr "DIARIO"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_bankbook_report__sortby__sort_journal_partner
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_cashbook_report__sortby__sort_journal_partner
+#, fuzzy
+msgid "Journal & Partner"
+msgstr "Diario & Socio"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#, fuzzy
+msgid "Journal and Partner"
+msgstr "Diario y Socio"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__journal_ids
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__journal_ids
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__journal_ids
+#, fuzzy
+msgid "Journals"
+msgstr "Diarios contables"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report____last_update
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report____last_update
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report____last_update
+#, fuzzy
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__write_uid
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__write_uid
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__write_uid
+#, fuzzy
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__write_date
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__write_date
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__write_date
+#, fuzzy
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Move"
+msgstr "Asiento"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_bankbook_report__target_move__posted
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_cashbook_report__target_move__posted
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_daybook_report__target_move__posted
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Posted Entries"
+msgstr "Entradas Publicadas"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.account_report_bankbook_view
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.account_report_cashbook_view
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.account_report_daybook_view
+#, fuzzy
+msgid "Print"
+msgstr "Imprimir"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_bankbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_cashbook
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.report_daybook
+#, fuzzy
+msgid "Ref"
+msgstr "Ref"
+
+#. module: om_account_daily_reports
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.account_report_bankbook_view
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.account_report_cashbook_view
+#: model_terms:ir.ui.view,arch_db:om_account_daily_reports.account_report_daybook_view
+#, fuzzy
+msgid "Report Options"
+msgstr "Opciones del informe"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__sortby
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__sortby
+#, fuzzy
+msgid "Sort by"
+msgstr "Ordenar por"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__date_from
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__date_from
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__date_from
+#, fuzzy
+msgid "Start Date"
+msgstr "Fecha inicial"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_bankbook_report__target_move
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_cashbook_report__target_move
+#: model:ir.model.fields,field_description:om_account_daily_reports.field_account_daybook_report__target_move
+#, fuzzy
+msgid "Target Moves"
+msgstr "Movimientos destino"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_bankbook_report__display_account__not_zero
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_cashbook_report__display_account__not_zero
+#, fuzzy
+msgid "With balance is not equal to 0"
+msgstr "Con saldo no es igual a 0"
+
+#. module: om_account_daily_reports
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_bankbook_report__display_account__movement
+#: model:ir.model.fields.selection,name:om_account_daily_reports.selection__account_cashbook_report__display_account__movement
+#, fuzzy
+msgid "With movements"
+msgstr "Con movimientos"

--- a/om_account_followup/i18n/es_CR.po
+++ b/om_account_followup/i18n/es_CR.po
@@ -1,0 +1,1812 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_account_followup
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 20:53+0000\n"
+"PO-Revision-Date: 2023-07-08 14:54-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_account_followup
+#: model:followup.line,description:om_account_followup.demo_followup_line3
+#, fuzzy
+msgid ""
+"\n"
+"                Dear %(partner_name)s,\n"
+"\n"
+"                Despite several reminders, your account is still not "
+"settled.\n"
+"\n"
+"                Unless full payment is made in next 8 days, then legal "
+"action\n"
+"                for the recovery of the debt will be taken without further\n"
+"                notice.\n"
+"\n"
+"                I trust that this action will prove unnecessary and details "
+"of\n"
+"                due payments is printed below.\n"
+"\n"
+"                In case of any queries concerning this matter, do not "
+"hesitate\n"
+"                to contact our accounting department.\n"
+"\n"
+"                Best Regards,\n"
+"            "
+msgstr ""
+"\n"
+"                Estimado %(partner_name)s,\n"
+"\n"
+"                A pesar de varios recordatorios, su cuenta aún no está "
+"saldada.\n"
+"\n"
+"                A menos que se realice el pago completo en los próximos 8 "
+"días, se emprenderán acciones legales\n"
+"                para la recuperación de la deuda se tomarán sin más\n"
+"                aviso.\n"
+"\n"
+"                Confío en que esta acción resultará innecesaria y los "
+"detalles de\n"
+"                de los pagos pendientes.\n"
+"\n"
+"                En caso de cualquier duda sobre este asunto, no dude en "
+"ponerse en contacto con nuestro departamento de contabilidad\n"
+"                en ponerse en contacto con nuestro departamento de "
+"contabilidad.\n"
+"\n"
+"                Saludos cordiales,\n"
+"            "
+
+#. module: om_account_followup
+#: model:followup.line,description:om_account_followup.demo_followup_line1
+#, fuzzy
+msgid ""
+"\n"
+"                Dear %(partner_name)s,\n"
+"\n"
+"                Exception made if there was a mistake of ours, it seems "
+"that\n"
+"                the following amount stays unpaid. Please, take "
+"appropriate\n"
+"                measures in order to carry out this payment in the next 8 "
+"days.\n"
+"\n"
+"                Would your payment have been carried out after this mail "
+"was\n"
+"                sent, please ignore this message. Do not hesitate to "
+"contact\n"
+"                our accounting department.\n"
+"\n"
+"                Best Regards,\n"
+"            "
+msgstr ""
+"\n"
+"                Estimado %(partner_name)s,\n"
+"\n"
+"                Excepción hecha si hubo un error nuestro, parece que\n"
+"                la siguiente cantidad permanece impagada. Por favor, tome "
+"las medidas\n"
+"                medidas para realizar este pago en los próximos 8 días.\n"
+"\n"
+"                Si su pago ha sido efectuado después del envío de este "
+"correo\n"
+"                enviado, por favor ignore este mensaje. No dude en ponerse "
+"en contacto\n"
+"                con nuestro departamento de contabilidad.\n"
+"\n"
+"                Saludos cordiales,\n"
+"            "
+
+#. module: om_account_followup
+#: model:followup.line,description:om_account_followup.demo_followup_line2
+#, fuzzy
+msgid ""
+"\n"
+"                Dear %(partner_name)s,\n"
+"\n"
+"                We are disappointed to see that despite sending a "
+"reminder,\n"
+"                that your account is now seriously overdue.\n"
+"\n"
+"                It is essential that immediate payment is made, otherwise "
+"we\n"
+"                will have to consider placing a stop on your account which\n"
+"                means that we will no longer be able to supply your "
+"company\n"
+"                with (goods/services).\n"
+"                Please, take appropriate measures in order to carry out "
+"this\n"
+"                payment in the next 8 days.\n"
+"\n"
+"                If there is a problem with paying invoice that we are not "
+"aware\n"
+"                of, do not hesitate to contact our accounting department, "
+"so\n"
+"                that we can resolve the matter quickly.\n"
+"\n"
+"                Details of due payments is printed below.\n"
+"\n"
+"                Best Regards,\n"
+"            "
+msgstr ""
+"\n"
+"                Estimado %(partner_name)s,\n"
+"\n"
+"                Estamos decepcionados de ver que a pesar de enviar un "
+"recordatorio,\n"
+"                que su cuenta está ahora seriamente atrasada.\n"
+"\n"
+"                Es esencial que efectúe el pago inmediatamente, de lo "
+"contrario\n"
+"                tendremos que considerar la posibilidad de bloquear su "
+"cuenta, lo que\n"
+"                lo que significa que ya no podremos suministrar a su "
+"empresa\n"
+"                (bienes/servicios) a su empresa.\n"
+"                Por favor, tome las medidas oportunas para realizar este\n"
+"                pago en los próximos 8 días.\n"
+"\n"
+"                Si hay algún problema con el pago de la factura que no "
+"conozcamos\n"
+"                que desconozcamos, no dude en ponerse en contacto con "
+"nuestro departamento de\n"
+"                que podamos resolver el asunto rápidamente.\n"
+"\n"
+"                A continuación encontrará información detallada sobre los "
+"pagos pendientes.\n"
+"\n"
+"                Saludos cordiales,\n"
+"            "
+
+#. module: om_account_followup
+#: model:mail.template,body_html:om_account_followup.email_template_om_account_followup_level0
+#, fuzzy
+msgid ""
+"\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
+"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: rgb(255, "
+"255, 255); \">\n"
+"\n"
+"    <p>Dear ${object.name},</p>\n"
+"    <p>\n"
+"    Exception made if there was a mistake of ours, it seems that the "
+"following amount stays unpaid. Please, take\n"
+"appropriate measures in order to carry out this payment in the next 8 "
+"days.\n"
+"\n"
+"Would your payment have been carried out after this mail was sent, please "
+"ignore this message. Do not hesitate to\n"
+"contact our accounting department.  \n"
+"\n"
+"    </p>\n"
+"<br/>\n"
+"Best Regards,\n"
+"<br/>\n"
+"   <br/>\n"
+"${user.name}\n"
+"\n"
+"<br/>\n"
+"<br/>\n"
+"\n"
+"\n"
+"${object.get_followup_table_html() | safe}\n"
+"\n"
+"    <br/>\n"
+"\n"
+"</div>\n"
+"            "
+msgstr ""
+"\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
+"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: rgb(255, "
+"255, 255); \">\n"
+"\n"
+" <p>Estimado ${object.name},</p>\n"
+"<p>\n"
+" Se hizo una excepción si hubo un error nuestro, parece que la siguiente "
+"cantidad sigue sin pagar. Por favor, tome\n"
+"medidas adecuadas para poder realizar este pago en los próximos 8 días.\n"
+"\n"
+"Si su pago se hubiera realizado después de que se envió este correo, ignore "
+"este mensaje. No dude en\n"
+"póngase en contacto con nuestro departamento de contabilidad. \n"
+"\n"
+"    </p>\n"
+"<br/>\n"
+"Saludos cordiales,\n"
+"<br/>\n"
+"   <br/>\n"
+"${user.name}\n"
+"\n"
+"<br/>\n"
+"<br/>\n"
+"\n"
+"\n"
+"${object.get_followup_table_html() | safe}\n"
+"\n"
+"    <br/>\n"
+"\n"
+"</div>\n"
+"            "
+
+#. module: om_account_followup
+#: model:mail.template,body_html:om_account_followup.email_template_om_account_followup_level2
+#, fuzzy
+msgid ""
+"\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
+"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: rgb(255, "
+"255, 255); \">\n"
+"    \n"
+"    <p>Dear ${object.name},</p>\n"
+"    <p>\n"
+"    Despite several reminders, your account is still not settled.\n"
+"Unless full payment is made in next 8 days, legal action for the recovery "
+"of the debt will be taken without\n"
+"further notice.\n"
+"I trust that this action will prove unnecessary and details of due payments "
+"is printed below.\n"
+"In case of any queries concerning this matter, do not hesitate to contact "
+"our accounting department.\n"
+"</p>\n"
+"<br/>\n"
+"Best Regards,\n"
+"<br/>\n"
+"<br/>\n"
+"${user.name}\n"
+"<br/>\n"
+"<br/>\n"
+"\n"
+"\n"
+"${object.get_followup_table_html() | safe}\n"
+"\n"
+"    <br/>\n"
+"\n"
+"</div>\n"
+"            "
+msgstr ""
+"\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
+"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: rgb(255, "
+"255, 255); \">\n"
+"    \n"
+" <p>Estimado ${object.name},</p>\n"
+"<p>\n"
+" A pesar de varios recordatorios, su cuenta aún no está liquidada.\n"
+"A menos que se realice el pago completo en los próximos 8 días, se "
+"emprenderán acciones legales para el cobro de la deuda sin\n"
+"aviso adicional.\n"
+"Confío en que esta acción resultará innecesaria y los detalles de los pagos "
+"adeudados se encuentran impresos a continuación.\n"
+"En caso de cualquier duda al respecto, no dude en contactar con nuestro "
+"departamento de contabilidad.\n"
+"</p>\n"
+"<br/>\n"
+"Saludos cordiales,\n"
+"<br/>\n"
+"<br/>\n"
+"${user.name}\n"
+"<br/>\n"
+"<br/>\n"
+"\n"
+"\n"
+"${object.get_followup_table_html() | safe}\n"
+"\n"
+"    <br/>\n"
+"\n"
+"</div>\n"
+"            "
+
+#. module: om_account_followup
+#: model:mail.template,body_html:om_account_followup.email_template_om_account_followup_default
+#, fuzzy
+msgid ""
+"\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
+"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: rgb(255, "
+"255, 255); \">\n"
+"    \n"
+"    <p>Dear ${object.name},</p>\n"
+"    <p>\n"
+"    Exception made if there was a mistake of ours, it seems that the "
+"following amount stays unpaid. Please, take\n"
+"appropriate measures in order to carry out this payment in the next 8 "
+"days.\n"
+"Would your payment have been carried out after this mail was sent, please "
+"ignore this message. Do not hesitate to\n"
+"contact our accounting department.\n"
+"    </p>\n"
+"<br/>\n"
+"Best Regards,\n"
+"<br/>\n"
+"<br/>\n"
+"${user.name}\n"
+"<br/>\n"
+"<br/>\n"
+"\n"
+"${object.get_followup_table_html() | safe}\n"
+"\n"
+"<br/>\n"
+"</div>\n"
+"            "
+msgstr ""
+"\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
+"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: rgb(255, "
+"255, 255); \">\n"
+"    \n"
+" <p>Estimado ${object.name},</p>\n"
+"<p>\n"
+" Se hizo una excepción si hubo un error nuestro, parece que la siguiente "
+"cantidad sigue sin pagar. Por favor, tome\n"
+"medidas adecuadas para poder realizar este pago en los próximos 8 días.\n"
+"Si su pago se hubiera realizado después de que se envió este correo, ignore "
+"este mensaje. No dude en\n"
+"póngase en contacto con nuestro departamento de contabilidad.\n"
+"    </p>\n"
+"<br/>\n"
+"Saludos cordiales,\n"
+"<br/>\n"
+"<br/>\n"
+"${user.name}\n"
+"<br/>\n"
+"<br/>\n"
+"\n"
+"${object.get_followup_table_html() | safe}\n"
+"\n"
+"<br/>\n"
+"</div>\n"
+"            "
+
+#. module: om_account_followup
+#: model:mail.template,body_html:om_account_followup.email_template_om_account_followup_level1
+#, fuzzy
+msgid ""
+"\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
+"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: rgb(255, "
+"255, 255); \">\n"
+"    \n"
+"    <p>Dear ${object.name},</p>\n"
+"   <p>\n"
+"    We are disappointed to see that despite sending a reminder, that your "
+"account is now seriously overdue.\n"
+"It is essential that immediate payment is made, otherwise we will have to "
+"consider placing a stop on your account\n"
+"which means that we will no longer be able to supply your company with "
+"(goods/services).\n"
+"Please, take appropriate measures in order to carry out this payment in the "
+"next 8 days.\n"
+"If there is a problem with paying invoice that we are not aware of, do not "
+"hesitate to contact our accounting\n"
+"department. so that we can resolve the matter quickly.\n"
+"Details of due payments is printed below.\n"
+" </p>\n"
+"<br/>\n"
+"Best Regards,\n"
+"    \n"
+"<br/>\n"
+"<br/>\n"
+"${user.name}\n"
+"    \n"
+"<br/>\n"
+"<br/>\n"
+"\n"
+"${object.get_followup_table_html() | safe}\n"
+"\n"
+"    <br/>\n"
+"\n"
+"</div>\n"
+"            "
+msgstr ""
+"\n"
+"<div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-"
+"serif; font-size: 12px; color: rgb(34, 34, 34); background-color: rgb(255, "
+"255, 255); \">\n"
+"    \n"
+" <p>Estimado ${object.name},</p>\n"
+"<p>\n"
+"Nos decepciona ver que, a pesar de enviar un recordatorio, su cuenta ahora "
+"está muy atrasada.\n"
+"Es esencial que se realice el pago de inmediato, de lo contrario tendremos "
+"que considerar detener su cuenta\n"
+"lo que significa que ya no podremos suministrar a su empresa (bienes/"
+"servicios).\n"
+"Por favor, tome las medidas adecuadas para poder realizar este pago en los "
+"próximos 8 días.\n"
+"Si hay un problema con el pago de la factura del que no tenemos "
+"conocimiento, no dude en ponerse en contacto con nuestra contabilidad\n"
+"departamento. para que podamos resolver el asunto rápidamente.\n"
+"Los detalles de los pagos adeudados se encuentran impresos a continuación.\n"
+" </p>\n"
+"<br/>\n"
+"Saludos cordiales,\n"
+"    \n"
+"<br/>\n"
+"<br/>\n"
+"${user.name}\n"
+"    \n"
+"<br/>\n"
+"<br/>\n"
+"\n"
+"${object.get_followup_table_html() | safe}\n"
+"\n"
+"    <br/>\n"
+"\n"
+"</div>\n"
+"            "
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid " email(s) sent"
+msgstr " correo(s) electrónico(s) enviado(s)"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid " email(s) should have been sent, but "
+msgstr " se deberían haber enviado correos electrónicos, pero "
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid " had unknown email address(es)"
+msgstr " tenía direcciones de correo electrónico desconocidas"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid " letter(s) in report"
+msgstr " carta en el reporte"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid " manual action(s) assigned:"
+msgstr " acción(es) manual(es) asignada(s):"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid " will be sent"
+msgstr " será enviado"
+
+#. module: om_account_followup
+#: model:mail.template,subject:om_account_followup.email_template_om_account_followup_default
+#: model:mail.template,subject:om_account_followup.email_template_om_account_followup_level0
+#: model:mail.template,subject:om_account_followup.email_template_om_account_followup_level1
+#: model:mail.template,subject:om_account_followup.email_template_om_account_followup_level2
+#, fuzzy
+msgid "${user.company_id.name} Payment Reminder"
+msgstr "${user.company_id.name} Recordatorio de pago"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid "%s partners have no credits and as such the action is cleared"
+msgstr "%s socios no tienen créditos y, por lo tanto, la acción se borra"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid ", the latest payment follow-up was:"
+msgstr ", el último seguimiento de pago fue:"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid ": Current Date"
+msgstr ": Fecha Actual"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid ": Partner Name"
+msgstr ": Nombre de Socio"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid ": User Name"
+msgstr ": Nombre de Usuario"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid ": User's Company Name"
+msgstr ": Nombre de la empresa del usuario"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.report_followup
+#, fuzzy
+msgid ""
+"<br/>\n"
+"                                Customer ref:"
+msgstr ""
+"<br/>\n"
+"                                Referencia del cliente:"
+
+#. module: om_account_followup
+#: model:mail.template,name:om_account_followup.email_template_om_account_followup_level1
+#, fuzzy
+msgid "A bit urging second payment follow-up reminder email"
+msgstr ""
+"Un poco instando al correo electrónico de recordatorio de seguimiento del "
+"segundo pago"
+
+#. module: om_account_followup
+#: model:ir.model,name:om_account_followup.model_followup_followup
+#, fuzzy
+msgid "Account Follow-up"
+msgstr "Seguimiento de cuenta"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid "Account Move line"
+msgstr "Entrada Contable"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__manual_action_note
+#, fuzzy
+msgid "Action To Do"
+msgstr "Acción a realizar"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid "Action to be taken e.g. Give a phonecall, Check if it's paid, ..."
+msgstr ""
+"Acción a tomar, p. Haz una llamada telefónica, comprueba si está pagado, ..."
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid "After"
+msgstr "Después de"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#: model_terms:ir.ui.view,arch_db:om_account_followup.report_followup
+#, fuzzy, python-format
+msgid "Amount"
+msgstr "Importe"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__payment_amount_due
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__payment_amount_due
+#, fuzzy
+msgid "Amount Due"
+msgstr "Importe adeudado"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__payment_amount_overdue
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__payment_amount_overdue
+#, fuzzy
+msgid "Amount Overdue"
+msgstr "Importe vencido"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#, fuzzy, python-format
+msgid "Amount due"
+msgstr "Importe adeudado"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid "Anybody"
+msgstr "Cualquiera"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__manual_action_responsible_id
+#, fuzzy
+msgid "Assign a Responsible"
+msgstr "Asignar un responsable"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__balance
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner__balance
+#, fuzzy
+msgid "Balance"
+msgstr "Saldo"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.om_account_followup_stat_by_partner_search
+#, fuzzy
+msgid "Balance > 0"
+msgstr "Saldo > 0"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_account_move_line__result
+#, fuzzy
+msgid "Balance Amount"
+msgstr "Monto de saldo"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid ""
+"Below is the history of the transactions of this\n"
+"                            customer. You can check \"No Follow-up\" in\n"
+"                            order to exclude it from the next follow-up\n"
+"                            actions."
+msgstr ""
+"A continuación se muestra el historial de las transacciones de este\n"
+"                            cliente. Puede marcar \"Sin seguimiento\" para\n"
+"                            excluirlo de las próximas acciones de "
+"seguimiento\n"
+"                            acciones."
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__blocked
+#, fuzzy
+msgid "Blocked"
+msgstr "Bloqueado"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_print
+#, fuzzy
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_followup_print__test_print
+#, fuzzy
+msgid ""
+"Check if you want to print follow-ups without changing follow-up level."
+msgstr ""
+"Marque si desea imprimir seguimientos sin cambiar el nivel de seguimiento."
+
+#. module: om_account_followup
+#: model_terms:ir.actions.act_window,help:om_account_followup.action_om_account_followup_definition_form
+#, fuzzy
+msgid "Click to define follow-up levels and their related actions."
+msgstr ""
+"Haga clic para definir los niveles de seguimiento y sus acciones "
+"relacionadas."
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid "Click to mark the action as done."
+msgstr "Haga clic para marcar la acción como realizada."
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_sending_results
+#, fuzzy
+msgid "Close"
+msgstr "Cerrar"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_followup__company_id
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__company_id
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__company_id
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner__company_id
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_stat_search
+#, fuzzy
+msgid "Company"
+msgstr "Compañía"
+
+#. module: om_account_followup
+#: model:ir.model,name:om_account_followup.model_res_config_settings
+msgid "Config Settings"
+msgstr "Opciones de configuración"
+
+#. module: om_account_followup
+#: model:ir.model,name:om_account_followup.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_followup__create_uid
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__create_uid
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__create_uid
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_sending_results__create_uid
+#, fuzzy
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_followup__create_date
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__create_date
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__create_date
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_sending_results__create_date
+#, fuzzy
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__credit
+#, fuzzy
+msgid "Credit"
+msgstr "Crédito"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.customer_followup_tree
+#, fuzzy
+msgid "Customer Followup"
+msgstr "Seguimiento del cliente"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__payment_note
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__payment_note
+#, fuzzy
+msgid "Customer Payment Promise"
+msgstr "Promesa de pago del cliente"
+
+#. module: om_account_followup
+#: model:ir.model.constraint,message:om_account_followup.constraint_followup_line_days_uniq
+#, fuzzy
+msgid "Days of the follow-up levels must be different"
+msgstr "Los días de los niveles de seguimiento deben ser diferentes"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__debit
+#, fuzzy
+msgid "Debit"
+msgstr "Débito"
+
+#. module: om_account_followup
+#: model:mail.template,name:om_account_followup.email_template_om_account_followup_default
+#, fuzzy
+msgid "Default payment follow-up reminder e-mail"
+msgstr ""
+"Correo electrónico de recordatorio de seguimiento de pago predeterminado"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_sending_results__description
+#: model_terms:ir.ui.view,arch_db:om_account_followup.report_followup
+#, fuzzy, python-format
+msgid "Description"
+msgstr "Descripción"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_followup__display_name
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__display_name
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__display_name
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_sending_results__display_name
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__display_name
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner__display_name
+#, fuzzy
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: om_account_followup
+#: model:ir.ui.menu,name:om_account_followup.om_account_followup_s
+#, fuzzy
+msgid "Do Manual Follow-Ups"
+msgstr "Hacer seguimientos manuales"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_followup_print__partner_lang
+#, fuzzy
+msgid ""
+"Do not change message text, if you want to send email in partner language, "
+"or configure from company"
+msgstr ""
+"No cambie el texto del mensaje, si desea enviar un correo electrónico en el "
+"idioma asociado, o configurar desde la empresa"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.report_followup
+#, fuzzy
+msgid ""
+"Document: Customer account statement\n"
+"                                <br/>\n"
+"                                Date:"
+msgstr ""
+"Documento: Extracto de cuenta del cliente\n"
+"                                <br/>\n"
+"                                Fecha:"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_sending_results
+#, fuzzy
+msgid "Download Letters"
+msgstr "Descargar cartas"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.report_followup
+#, fuzzy
+msgid "Due"
+msgstr "Debido"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#, fuzzy, python-format
+msgid "Due Date"
+msgstr "Fecha de vencimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__delay
+#, fuzzy
+msgid "Due Days"
+msgstr "Días de vencimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__email_body
+#, fuzzy
+msgid "Email Body"
+msgstr "Cuerpo del correo electronico"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__email_subject
+#, fuzzy
+msgid "Email Subject"
+msgstr "Asunto del correo"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__email_template_id
+#, fuzzy
+msgid "Email Template"
+msgstr "Plantilla del correo"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#, fuzzy, python-format
+msgid "Email not sent because of email address of partner not filled in"
+msgstr ""
+"Correo electrónico no enviado debido a que la dirección de correo "
+"electrónico del socio no se completó"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__date_move
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner__date_move
+#, fuzzy
+msgid "First move"
+msgstr "Primer asiento"
+
+#. module: om_account_followup
+#: model:mail.template,name:om_account_followup.email_template_om_account_followup_level0
+#, fuzzy
+msgid "First polite payment follow-up reminder email"
+msgstr ""
+"Primer correo electrónico de recordatorio de seguimiento de pago cortés"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__followup_id
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__followup_id
+#, fuzzy
+msgid "Follow Ups"
+msgstr "Seguimientos"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__followup_id
+#, fuzzy
+msgid "Follow-Up"
+msgstr "Seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__name
+#, fuzzy
+msgid "Follow-Up Action"
+msgstr "Acción de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.ui.menu,name:om_account_followup.menu_finance_followup
+#, fuzzy
+msgid "Follow-Ups"
+msgstr "Seguimientos"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_followup__followup_line
+#: model:ir.ui.menu,name:om_account_followup.om_account_followup_main_menu
+#: model_terms:ir.ui.view,arch_db:om_account_followup.customer_followup_search_view
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_form
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_tree
+#, fuzzy
+msgid "Follow-up"
+msgstr "Seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model,name:om_account_followup.model_followup_line
+#, fuzzy
+msgid "Follow-up Criteria"
+msgstr "Criterios de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_account_move_line__followup_line_id
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_stat_search
+#, fuzzy
+msgid "Follow-up Level"
+msgstr "Nivel de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.actions.act_window,name:om_account_followup.action_om_account_followup_definition_form
+#: model:ir.ui.menu,name:om_account_followup.om_account_followup_menu
+#, fuzzy
+msgid "Follow-up Levels"
+msgstr "Niveles de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.actions.report,name:om_account_followup.action_report_followup
+#, fuzzy
+msgid "Follow-up Report"
+msgstr "Informe de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__payment_responsible_id
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__payment_responsible_id
+#: model_terms:ir.ui.view,arch_db:om_account_followup.customer_followup_search_view
+#, fuzzy
+msgid "Follow-up Responsible"
+msgstr "Responsable de Seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__date
+#, fuzzy
+msgid "Follow-up Sending Date"
+msgstr "Fecha de envío de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model,name:om_account_followup.model_followup_stat
+#, fuzzy
+msgid "Follow-up Statistics"
+msgstr "Estadísticas de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model,name:om_account_followup.model_followup_stat_by_partner
+#, fuzzy
+msgid "Follow-up Statistics by Partner"
+msgstr "Estadísticas de seguimiento por socio"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_tree
+#, fuzzy
+msgid "Follow-up Steps"
+msgstr "Pasos de seguimiento"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid "Follow-up letter of "
+msgstr "Carta de seguimiento de "
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_stat_graph
+#, fuzzy
+msgid "Follow-up lines"
+msgstr "Líneas de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.actions.act_window,name:om_account_followup.action_followup_stat
+#: model:ir.ui.menu,name:om_account_followup.menu_action_followup_stat_follow
+#, fuzzy
+msgid "Follow-ups Analysis"
+msgstr "Análisis de seguimientos"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_stat_search
+#, fuzzy
+msgid "Follow-ups Sent"
+msgstr "Seguimientos enviados"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.customer_followup_search_view
+#, fuzzy
+msgid "Follow-ups To Do"
+msgstr "Seguimientos por hacer"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.customer_followup_search_view
+#, fuzzy
+msgid "Followup Level"
+msgstr "Nivel de seguimiento"
+
+#. module: om_account_followup
+#: model_terms:ir.actions.act_window,help:om_account_followup.action_om_account_followup_definition_form
+#, fuzzy
+msgid ""
+"For each step, specify the actions to be taken and delay in\n"
+"                    days. It is\n"
+"                    possible to use print and e-mail templates to send "
+"specific\n"
+"                    messages to\n"
+"                    the customer."
+msgstr ""
+"Para cada paso, especifique las acciones a realizar y la demora\n"
+"                    días. Son\n"
+"                    es posible utilizar plantillas impresas y de correo "
+"electrónico para enviar mensajes específicos\n"
+"                    mensajes para\n"
+"                    el cliente."
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_followup_line__sequence
+#: model:ir.model.fields,help:om_account_followup.field_res_partner__latest_followup_sequence
+#: model:ir.model.fields,help:om_account_followup.field_res_users__latest_followup_sequence
+#, fuzzy
+msgid "Gives the sequence order when displaying a list of follow-up lines."
+msgstr ""
+"Da el orden de la secuencia al mostrar una lista de líneas de seguimiento."
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_stat_search
+#, fuzzy
+msgid "Group By"
+msgstr "Agrupar por"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid ""
+"He said the problem was temporary and promised to pay 50% before 15th of "
+"May, balance before 1st of July."
+msgstr ""
+"Dijo que el problema era temporal y prometió pagar el 50% antes del 15 de "
+"mayo y el resto antes del 1 de julio."
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_followup__id
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__id
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__id
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_sending_results__id
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__id
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner__id
+#, fuzzy
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid ""
+"If not specified by the latest follow-up level, it will send from the "
+"default email template"
+msgstr ""
+"Si no lo especifica el último nivel de seguimiento, se enviará desde el "
+"plantilla de correo electrónico predeterminada"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_stat_search
+#, fuzzy
+msgid "Including journal entries marked as a litigation"
+msgstr "Incluir asientos de diario marcados como litigios"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner__invoice_partner_id
+#, fuzzy
+msgid "Invoice Address"
+msgstr "Dirección de facturación"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#: model_terms:ir.ui.view,arch_db:om_account_followup.report_followup
+#, fuzzy, python-format
+msgid "Invoice Date"
+msgstr "Fecha de factura"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid "Invoices Reminder"
+msgstr "Recordatorio de facturas"
+
+#. module: om_account_followup
+#: model:ir.model,name:om_account_followup.model_account_move_line
+msgid "Journal Item"
+msgstr "Apunte contable"
+
+#. module: om_account_followup
+#: model:ir.actions.act_window,name:om_account_followup.account_manual_reconcile_action
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_move_line_reconcile_tree
+#, fuzzy
+msgid "Journal Items to Reconcile"
+msgstr "Diarios de partidas a conciliar"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_followup____last_update
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line____last_update
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print____last_update
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_sending_results____last_update
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat____last_update
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner____last_update
+#, fuzzy
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_followup__write_uid
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__write_uid
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__write_uid
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_sending_results__write_uid
+#, fuzzy
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_followup__write_date
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__write_date
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__write_date
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_sending_results__write_date
+#, fuzzy
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__date_move_last
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner__date_move_last
+#, fuzzy
+msgid "Last move"
+msgstr "Último asiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_account_move_line__followup_date
+#, fuzzy
+msgid "Latest Follow-up"
+msgstr "Último seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__latest_followup_date
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__latest_followup_date
+#, fuzzy
+msgid "Latest Follow-up Date"
+msgstr "Última fecha de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__latest_followup_level_id
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__latest_followup_level_id
+#, fuzzy
+msgid "Latest Follow-up Level"
+msgstr "Último nivel de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__latest_followup_level_id_without_lit
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__latest_followup_level_id_without_lit
+#, fuzzy
+msgid "Latest Follow-up Level without litigation"
+msgstr "Último Nivel de Seguimiento sin litigio"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_stat_search
+#, fuzzy
+msgid "Latest Follow-up Month"
+msgstr "Último mes de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_res_partner__latest_followup_date
+#: model:ir.model.fields,help:om_account_followup.field_res_users__latest_followup_date
+#, fuzzy
+msgid "Latest date that the follow-up level of the partner was changed"
+msgstr "Última fecha en la que se cambió el nivel de seguimiento del socio"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner__date_followup
+#, fuzzy
+msgid "Latest follow-up"
+msgstr "Último seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__date_followup
+#, fuzzy
+msgid "Latest followup"
+msgstr "Último seguimiento"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#, fuzzy, python-format
+msgid "Lit."
+msgstr "Cobro Judicial"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_stat_search
+#, fuzzy
+msgid "Litigation"
+msgstr "Cobro Judicial"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__manual_action
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid "Manual Action"
+msgstr "Acción manual"
+
+#. module: om_account_followup
+#: model:ir.actions.act_window,name:om_account_followup.action_customer_followup
+#, fuzzy
+msgid "Manual Follow-Ups"
+msgstr "Seguimientos manuales"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.report_followup
+#, fuzzy
+msgid "Maturity Date"
+msgstr "Fecha de vencimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner__max_followup_id
+#, fuzzy
+msgid "Max Follow Up Level"
+msgstr "Nivel máximo de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.actions.act_window,name:om_account_followup.action_customer_my_followup
+#: model:ir.ui.menu,name:om_account_followup.menu_sale_followup
+#, fuzzy
+msgid "My Follow-Ups"
+msgstr "Mis seguimientos"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.customer_followup_search_view
+#, fuzzy
+msgid "My Follow-ups"
+msgstr "Mis seguimientos"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_followup__name
+#, fuzzy
+msgid "Name"
+msgstr "Nombre"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_sending_results__needprinting
+#, fuzzy
+msgid "Needs Printing"
+msgstr "Necesita impresión"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__payment_next_action
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__payment_next_action
+#, fuzzy
+msgid "Next Action"
+msgstr "Siguiente Acción"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__payment_next_action_date
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__payment_next_action_date
+#, fuzzy
+msgid "Next Action Date"
+msgstr "Próxima fecha de acción"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.customer_followup_search_view
+#, fuzzy
+msgid "No Responsible"
+msgstr "Sin Responsable"
+
+#. module: om_account_followup
+#: model_terms:ir.actions.act_window,help:om_account_followup.account_manual_reconcile_action
+#, fuzzy
+msgid "No journal items found."
+msgstr "No se encontraron elementos de diario."
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_stat_search
+#, fuzzy
+msgid "Not Litigation"
+msgstr "No litigio"
+
+#. module: om_account_followup
+#: model:ir.model.constraint,message:om_account_followup.constraint_followup_followup_company_uniq
+#, fuzzy
+msgid "Only one follow-up per company is allowed"
+msgstr "Solo se permite un seguimiento por empresa"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_res_partner__payment_responsible_id
+#: model:ir.model.fields,help:om_account_followup.field_res_users__payment_responsible_id
+#, fuzzy
+msgid ""
+"Optionally you can assign a user to this field, which will make him "
+"responsible for the action."
+msgstr ""
+"Opcionalmente, puede asignar un usuario a este campo, lo que lo hará "
+"responsable de la acción."
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#, fuzzy, python-format
+msgid "Overdue email sent to %s, "
+msgstr "Correo electrónico vencido enviado a %s, "
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat__partner_id
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_stat_by_partner__partner_id
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_stat_search
+#, fuzzy
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.account_move_line_partner_tree
+#, fuzzy
+msgid "Partner Entries"
+msgstr "Entradas de socios"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.om_account_followup_stat_by_partner_search
+#: model_terms:ir.ui.view,arch_db:om_account_followup.om_account_followup_stat_by_partner_tree
+#, fuzzy
+msgid "Partner to Remind"
+msgstr "Socio para recordar"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__partner_ids
+#, fuzzy
+msgid "Partners"
+msgstr "Sucursales"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.customer_followup_search_view
+#, fuzzy
+msgid "Partners with Overdue Credits"
+msgstr "Socios con créditos vencidos"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid "Payment Follow-up"
+msgstr "Seguimiento de pagos"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_res_partner__payment_note
+#: model:ir.model.fields,help:om_account_followup.field_res_users__payment_note
+#, fuzzy
+msgid "Payment Note"
+msgstr "Nota de pago"
+
+#. module: om_account_followup
+#: model:ir.model,name:om_account_followup.model_followup_print
+#, fuzzy
+msgid "Print Follow-up & Send Mail to Customers"
+msgstr "Imprimir seguimiento y enviar correo a los clientes"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid "Print Overdue Payments"
+msgstr "Imprimir pagos atrasados"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid "Print overdue payments report independent of follow-up line"
+msgstr ""
+"Imprimir informe de pagos atrasados independiente de la línea de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__description
+#, fuzzy
+msgid "Printed Message"
+msgstr "Mensaje impreso"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#, fuzzy, python-format
+msgid "Printed overdue payments report"
+msgstr "Informe impreso de pagos atrasados"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.report_followup
+#, fuzzy
+msgid "Ref"
+msgstr "Ref"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#, fuzzy, python-format
+msgid "Reference"
+msgstr "Referencia"
+
+#. module: om_account_followup
+#: model:ir.model,name:om_account_followup.model_report_om_account_followup_report_followup
+#, fuzzy
+msgid "Report Followup"
+msgstr "Seguimiento del informe"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid "Responsible of credit collection"
+msgstr "Responsable del cobro de créditos"
+
+#. module: om_account_followup
+#: model:ir.model,name:om_account_followup.model_followup_sending_results
+#, fuzzy
+msgid "Results from the sending of the different letters and emails"
+msgstr "Resultados del envío de las diferentes cartas y correos electrónicos"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_filter
+#, fuzzy
+msgid "Search Follow-up"
+msgstr "Seguimiento de búsqueda"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__email_conf
+#, fuzzy
+msgid "Send Email Confirmation"
+msgstr "Enviar confirmación por correo electrónico"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__partner_lang
+#, fuzzy
+msgid "Send Email in Partner Language"
+msgstr "Enviar correo electrónico en el idioma del socio"
+
+#. module: om_account_followup
+#: model:ir.actions.act_window,name:om_account_followup.action_om_account_followup_print
+#, fuzzy
+msgid "Send Follow-Ups"
+msgstr "Enviar seguimientos"
+
+#. module: om_account_followup
+#: model:ir.ui.menu,name:om_account_followup.om_account_followup_print_menu
+#, fuzzy
+msgid "Send Letters and Emails"
+msgstr "Enviar cartas y correos electrónicos"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/wizard/followup_print.py:0
+#, fuzzy, python-format
+msgid "Send Letters and Emails: Actions Summary"
+msgstr "Enviar cartas y correos electrónicos: resumen de acciones"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid "Send Overdue Email"
+msgstr "Enviar correo electrónico vencido"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__send_letter
+#, fuzzy
+msgid "Send a Letter"
+msgstr "Enviar una carta"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid "Send a Letter or Email"
+msgstr "Enviar una carta o correo electrónico"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__send_email
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid "Send an Email"
+msgstr "Envía tu correo electrónico a"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_print
+#, fuzzy
+msgid "Send emails and generate letters"
+msgstr "Enviar correos electrónicos y generar cartas"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_print
+#, fuzzy
+msgid "Send follow-ups"
+msgstr "Enviar seguimientos"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_line__sequence
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__latest_followup_sequence
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__latest_followup_sequence
+#, fuzzy
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__summary
+#, fuzzy
+msgid "Summary"
+msgstr "Resumen"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_sending_results
+#, fuzzy
+msgid "Summary of actions"
+msgstr "Resumen de las acciones"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_followup_print__test_print
+#, fuzzy
+msgid "Test Print"
+msgstr "Impresión de prueba"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid "The"
+msgstr "el"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/report/followup_print.py:0
+#, fuzzy, python-format
+msgid ""
+"The followup plan defined for the current company does not have any "
+"followup action."
+msgstr ""
+"El plan de seguimiento definido para la empresa actual no tiene ninguna "
+"acción de seguimiento."
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_res_partner__latest_followup_level_id
+#: model:ir.model.fields,help:om_account_followup.field_res_users__latest_followup_level_id
+#, fuzzy
+msgid "The maximum follow-up level"
+msgstr "El nivel máximo de seguimiento"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_res_partner__latest_followup_level_id_without_lit
+#: model:ir.model.fields,help:om_account_followup.field_res_users__latest_followup_level_id_without_lit
+#, fuzzy
+msgid ""
+"The maximum follow-up level without taking into account the account move "
+"lines with litigation"
+msgstr ""
+"El máximo nivel de seguimiento sin tener en cuenta las líneas de movimiento "
+"de cuenta con litigios"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_followup_line__delay
+#, fuzzy
+msgid ""
+"The number of days after the due date of the invoice to wait before sending "
+"the reminder. Could be negative if you want to send a polite alert "
+"beforehand."
+msgstr ""
+"El número de días después de la fecha de vencimiento de la factura que se "
+"debe esperar antes de enviar el recordatorio. Podría ser negativo si desea "
+"enviar una alerta cortés de antemano."
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#, fuzzy, python-format
+msgid ""
+"The partner does not have any accounting entries to print in the overdue "
+"report for the current company."
+msgstr ""
+"El socio no tiene ninguna entrada contable para imprimir en el informe "
+"vencido de la empresa actual."
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#, fuzzy, python-format
+msgid "There is no followup plan defined for the current company."
+msgstr "No hay un plan de seguimiento definido para la empresa actual."
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_print
+#, fuzzy
+msgid ""
+"This action will send follow-up emails, print the\n"
+"                        letters and\n"
+"                        set the manual actions per customer, according to "
+"the\n"
+"                        follow-up levels defined."
+msgstr ""
+"Esta acción enviará correos electrónicos de seguimiento, imprima el\n"
+"                        cartas y\n"
+"                        Establezca las acciones manuales por cliente, de "
+"acuerdo con el\n"
+"                        Definición de niveles de seguimiento."
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_followup_print__date
+#, fuzzy
+msgid "This field allow you to select a forecast date to plan your follow-ups"
+msgstr ""
+"Este campo le permite seleccionar una fecha de pronóstico para planificar "
+"sus seguimientos"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_res_partner__payment_next_action
+#: model:ir.model.fields,help:om_account_followup.field_res_users__payment_next_action
+#, fuzzy
+msgid ""
+"This is the next action to be taken.  It will automatically be set when the "
+"partner gets a follow-up level that requires a manual action. "
+msgstr ""
+"Esta es la siguiente acción a tomar.  Se establecerá automáticamente cuando "
+"el socio obtenga un nivel de seguimiento que requiera una acción manual. "
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_res_partner__payment_next_action_date
+#: model:ir.model.fields,help:om_account_followup.field_res_users__payment_next_action_date
+#, fuzzy
+msgid ""
+"This is when the manual follow-up is needed. The date will be set to the "
+"current date when the partner gets a follow-up level that requires a manual "
+"action. Can be practical to set manually e.g. to see if he keeps his "
+"promises."
+msgstr ""
+"Aquí es cuando se necesita el seguimiento manual. La fecha se establecerá "
+"en la fecha actual cuando el socio obtenga un nivel de seguimiento que "
+"requiera una acción manual. Puede ser práctico configurarlo manualmente, "
+"por ejemplo, para ver si cumple sus promesas."
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_form
+#, fuzzy
+msgid ""
+"To remind customers of paying their invoices, you can\n"
+"                        define different actions depending on how severely\n"
+"                        overdue the customer is. These actions are bundled\n"
+"                        into follow-up levels that are triggered when the "
+"due\n"
+"                        date of an invoice has passed a certain\n"
+"                        number of days. If there are other overdue invoices "
+"for\n"
+"                        the\n"
+"                        same customer, the actions of the most\n"
+"                        overdue invoice will be executed."
+msgstr ""
+"Para recordar a los clientes el pago de sus facturas, puede\n"
+"                        Definir diferentes acciones dependiendo de la "
+"severidad con la que se\n"
+"                        atrasado el cliente está. Estas acciones se "
+"agrupan\n"
+"                        en niveles de seguimiento que se activan cuando el "
+"debido\n"
+"                        fecha de una factura ha pasado un cierto\n"
+"                        número de días. Si hay otras facturas vencidas "
+"para\n"
+"                        el\n"
+"                        mismo cliente, las acciones de la mayoría\n"
+"                        Se ejecutará la factura vencida."
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.account_move_line_partner_tree
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_move_line_reconcile_tree
+#, fuzzy
+msgid "Total credit"
+msgstr "Crédito total"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.account_move_line_partner_tree
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_move_line_reconcile_tree
+#, fuzzy
+msgid "Total debit"
+msgstr "Débito total"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.report_followup
+#, fuzzy
+msgid "Total:"
+msgstr "Total:"
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__unreconciled_aml_ids
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__unreconciled_aml_ids
+#, fuzzy
+msgid "Unreconciled Aml"
+msgstr "Aml no reconciliado"
+
+#. module: om_account_followup
+#: model:mail.template,name:om_account_followup.email_template_om_account_followup_level2
+#, fuzzy
+msgid "Urging payment follow-up reminder email"
+msgstr "Instando al correo electrónico de recordatorio de seguimiento de pago"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_followup_line__send_letter
+#, fuzzy
+msgid "When processing, it will print a letter"
+msgstr "Al procesar, imprimirá una carta"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_followup_line__send_email
+#, fuzzy
+msgid "When processing, it will send an email"
+msgstr "Al procesar, enviará un correo electrónico"
+
+#. module: om_account_followup
+#: model:ir.model.fields,help:om_account_followup.field_followup_line__manual_action
+#, fuzzy
+msgid ""
+"When processing, it will set the manual action to be taken for that "
+"customer. "
+msgstr ""
+"Al procesar, establecerá la acción manual que se realizará para ese "
+"cliente. "
+
+#. module: om_account_followup
+#: model:ir.model.fields,field_description:om_account_followup.field_res_partner__payment_earliest_due_date
+#: model:ir.model.fields,field_description:om_account_followup.field_res_users__payment_earliest_due_date
+#, fuzzy
+msgid "Worst Due Date"
+msgstr "Peor fecha de vencimiento"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid ""
+"Write here the introduction in the letter,\n"
+"                            according to the level of the follow-up. You "
+"can\n"
+"                            use the following keywords in the text. Don't\n"
+"                            forget to translate in all languages you "
+"installed\n"
+"                            using to top right icon."
+msgstr ""
+"Escribe aquí la introducción en la carta,\n"
+"                            según el nivel del seguimiento. Puedes\n"
+"                            Utilice las siguientes palabras clave en el "
+"texto. No\n"
+"                            Olvídate de traducir en todos los idiomas que "
+"instalaste\n"
+"                            usando el icono superior derecho."
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/partner.py:0
+#, fuzzy, python-format
+msgid ""
+"You became responsible to do the next action for the payment follow-up of"
+msgstr ""
+"Usted se convirtió en responsable de hacer la siguiente acción para el "
+"seguimiento del pago de"
+
+#. module: om_account_followup
+#. odoo-python
+#: code:addons/om_account_followup/models/followup.py:0
+#, fuzzy, python-format
+msgid ""
+"Your description is invalid, use the right legend or %% if you want to use "
+"the percent character."
+msgstr ""
+"Su descripción no es válida, use la leyenda o %% correcta si desea usar el "
+"carácter de porcentaje."
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid "days overdue, do the following actions:"
+msgstr "días de retraso, realice las siguientes acciones:"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_followup_line_form
+#, fuzzy
+msgid "e.g. Call the customer, check if it's paid, ..."
+msgstr "por ejemplo, llamar al cliente, comprobar si está pagado, ..."
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_om_account_followup_print
+#, fuzzy
+msgid "or"
+msgstr "o"
+
+#. module: om_account_followup
+#: model_terms:ir.ui.view,arch_db:om_account_followup.view_partner_inherit_followup_form
+#, fuzzy
+msgid "⇾ Mark as Done"
+msgstr "⇾ Marcar como hecho"

--- a/om_data_remove/i18n/es_CR.po
+++ b/om_data_remove/i18n/es_CR.po
@@ -1,0 +1,257 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_data_remove
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 20:55+0000\n"
+"PO-Revision-Date: 2023-07-08 14:56-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid ""
+"<span class=\"col-3 col-lg-2 text-start\">\n"
+"                                Accounting <span title=\"Values set "
+"here are company-specific.\" groups=\"base.group_multi_company\"/>\n"
+"                            </span>"
+msgstr ""
+"<span class=\"col-3 col-lg-2 text-start\">\n"
+"                                Contabilidad <span title=\"Los valores establecidos "
+"aquí son específicos de la empresa.\" groups=\"base.group_multi_company\"/>\n"
+"                            </span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">Base Models</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">Modelos base</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">Expense</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">Gasto</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">Inventory</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">Inventario</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">MRP</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">MRP</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">POS</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">POS</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">Project</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">Proyecto</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">Purchase</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">Compra</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">Quality</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">Calidad</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">Remove All</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">Eliminar todo</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">Sale</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">Venta</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "<span class=\"col-3 col-lg-2 text-start\">Website And Blog</span>"
+msgstr "<span class=\"col-3 col-lg-2 text-start\">Sitio web y blog</span>"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Clean and reset Account Chart"
+msgstr "Limpiar y restablecer el gráfico de la cuenta"
+
+#. module: om_data_remove
+#: model:ir.model,name:om_data_remove.model_res_config_settings
+msgid "Config Settings"
+msgstr "Opciones de configuración"
+
+#. module: om_data_remove
+#: model:ir.actions.act_window,name:om_data_remove.action_remove_data
+#, fuzzy
+msgid "Customize Debrand"
+msgstr "Personalizar Debrand"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Data Cleaning (Be careful to do that!)"
+msgstr "Limpieza de datos (¡Tenga cuidado de hacer eso!)"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid ""
+"Data is deleted direcly from the database table using queries, once you "
+"done, it is not reversible !"
+msgstr ""
+"Los datos se eliminan directamente de la tabla de la base de datos "
+"mediante consultas, una vez que haya terminado, ¡no es reversible!"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All BOM"
+msgstr "Eliminar todas las listas de materiales"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Expense and Sheet"
+msgstr "Eliminar todos los gastos y la hoja"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Manufacturing Order"
+msgstr "Eliminar toda la orden de fabricación"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Message"
+msgstr "Eliminar todo el mensaje"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Move/Picking/Package/Lot"
+msgstr "Eliminar todos los movimientos / selección / paquete / lote"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All POS Order"
+msgstr "Eliminar todos los pedidos de POS"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Product"
+msgstr "Eliminar todo el producto"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Product Attribute"
+msgstr "Eliminar todos los atributos de producto"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Project/Task/Forecast"
+msgstr "Eliminar todo el proyecto/tarea/previsión"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Purchase Order and Requisition"
+msgstr "Eliminar todos los pedidos de compra y solicitudes"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Quality"
+msgstr "Eliminar toda la calidad"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Quality Setting"
+msgstr "Eliminar toda la configuración de calidad"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Sales Order"
+msgstr "Eliminar todos los pedidos de cliente"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Transactions Except Master Data"
+msgstr "Eliminar todas las transacciones excepto los datos maestros"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Voucher/Invoice/Bill"
+msgstr "Eliminar todo el comprobante/factura/factura"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Delete All Website/Blog"
+msgstr "Eliminar todo el sitio web / blog"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Please confirm to delete the data?"
+msgstr "¿Confirma que quieres eliminar los datos?"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Please confirm to delete the select data?"
+msgstr "Por favor, confirme para eliminar los datos seleccionados?"
+
+#. module: om_data_remove
+#: model:ir.ui.menu,name:om_data_remove.menu_remove_data
+#, fuzzy
+msgid "Remove Data"
+msgstr "Eliminar datos"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "Reset Category And Location Complete Name"
+msgstr "Restablecer categoría y ubicación Nombre completo"
+
+#. module: om_data_remove
+#: model_terms:ir.ui.view,arch_db:om_data_remove.view_remove_data
+#, fuzzy
+msgid "odooApp Customize Settings"
+msgstr "odooApp Personalizar Configuración"

--- a/om_fiscal_year/i18n/es_CR.po
+++ b/om_fiscal_year/i18n/es_CR.po
@@ -1,0 +1,352 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_fiscal_year
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 20:58+0000\n"
+"PO-Revision-Date: 2023-07-08 14:59-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_fiscal_year
+#: model_terms:ir.ui.view,arch_db:om_fiscal_year.view_change_lock_date
+#, fuzzy
+msgid "Account Period Closing"
+msgstr "Cierre del período de la cuenta"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_res_config_settings__fiscalyear_lock_date
+#, fuzzy
+msgid "All Users Lock Date"
+msgstr "Fecha de bloqueo para todos los usuarios"
+
+#. module: om_fiscal_year
+#: model:res.groups,name:om_fiscal_year.group_fiscal_year
+#, fuzzy
+msgid "Allow to define fiscal years of more or less than a year"
+msgstr "Permite definir años fiscales para más de 1 año o menos de 1 año."
+
+#. module: om_fiscal_year
+#: model_terms:ir.ui.view,arch_db:om_fiscal_year.view_change_lock_date
+#, fuzzy
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: om_fiscal_year
+#: model:ir.model,name:om_fiscal_year.model_change_lock_date
+#, fuzzy
+msgid "Change Lock Date"
+msgstr "Cambiar fecha de bloqueo"
+
+#. module: om_fiscal_year
+#: model_terms:ir.actions.act_window,help:om_fiscal_year.actions_account_fiscal_year
+#, fuzzy
+msgid "Click here to create a new fiscal year."
+msgstr "Haz clic aquí para crear un nuevo año fiscal."
+
+#. module: om_fiscal_year
+#: model:ir.model,name:om_fiscal_year.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year__company_id
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date__company_id
+#, fuzzy
+msgid "Company"
+msgstr "Compañía"
+
+#. module: om_fiscal_year
+#: model:ir.model,name:om_fiscal_year.model_res_config_settings
+msgid "Config Settings"
+msgstr "Opciones de configuración"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year__create_uid
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date__create_uid
+#, fuzzy
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year__create_date
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date__create_date
+#, fuzzy
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: om_fiscal_year
+#: model_terms:ir.ui.view,arch_db:om_fiscal_year.res_config_settings_view_form
+#, fuzzy
+msgid "Define fiscal years of more or less than one year"
+msgstr "Definir años fiscales de más de 1 año o menos de 1 año."
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year__display_name
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date__display_name
+#, fuzzy
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year__date_to
+#, fuzzy
+msgid "End Date"
+msgstr "Fecha final"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,help:om_fiscal_year.field_account_fiscal_year__date_to
+#, fuzzy
+msgid "Ending Date, included in the fiscal year."
+msgstr "Fecha límite, incluida en el ejercicio fiscal."
+
+#. module: om_fiscal_year
+#: model_terms:ir.ui.view,arch_db:om_fiscal_year.res_config_settings_view_form
+#, fuzzy
+msgid "Fiscal Period Closing"
+msgstr "Cierre del período fiscal"
+
+#. module: om_fiscal_year
+#: model:ir.model,name:om_fiscal_year.model_account_fiscal_year
+#: model:ir.ui.menu,name:om_fiscal_year.menu_fiscal_year
+#: model_terms:ir.ui.view,arch_db:om_fiscal_year.res_config_settings_view_form
+#, fuzzy
+msgid "Fiscal Year"
+msgstr "Año fiscal"
+
+#. module: om_fiscal_year
+#: model:ir.actions.act_window,name:om_fiscal_year.actions_account_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_res_config_settings__group_fiscal_year
+#: model_terms:ir.ui.view,arch_db:om_fiscal_year.res_config_settings_view_form
+#, fuzzy
+msgid "Fiscal Years"
+msgstr "Ejercicio fiscal"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_res_config_settings__fiscalyear_last_day
+#, fuzzy
+msgid "Fiscalyear Last Day"
+msgstr "Último día del año fiscal"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_res_config_settings__fiscalyear_last_month
+#, fuzzy
+msgid "Fiscalyear Last Month"
+msgstr "Último mes del año fiscal"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year__id
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date__id
+#, fuzzy
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date__period_lock_date
+#, fuzzy
+msgid "Journal Entries Lock Date"
+msgstr "Fecha de bloqueo de asientos de diario"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_res_config_settings__period_lock_date
+#, fuzzy
+msgid "Journals Entries Lock Date"
+msgstr "Entradas de diarios Fecha de bloqueo"
+
+#. module: om_fiscal_year
+#: model_terms:ir.ui.view,arch_db:om_fiscal_year.res_config_settings_view_form
+#, fuzzy
+msgid "Last Day"
+msgstr "Último día"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year____last_update
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date____last_update
+#, fuzzy
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year__write_uid
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date__write_uid
+#, fuzzy
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year__write_date
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date__write_date
+#, fuzzy
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date__fiscalyear_lock_date
+#, fuzzy
+msgid "Lock Date for All Users"
+msgstr "Bloquea una fecha para todos los usuarios"
+
+#. module: om_fiscal_year
+#: model:ir.ui.menu,name:om_fiscal_year.menu_action_change_lock_date
+#, fuzzy
+msgid "Lock Dates"
+msgstr "Fechas bloqueadas"
+
+#. module: om_fiscal_year
+#: model:ir.actions.act_window,name:om_fiscal_year.action_view_change_lock_date
+#, fuzzy
+msgid "Lock your Fiscal Period"
+msgstr "Bloquee su período fiscal"
+
+#. module: om_fiscal_year
+#: model_terms:ir.ui.view,arch_db:om_fiscal_year.res_config_settings_view_form
+#, fuzzy
+msgid "Lock your fiscal period"
+msgstr "Bloquea tu período fiscal"
+
+#. module: om_fiscal_year
+#: model_terms:ir.ui.view,arch_db:om_fiscal_year.view_change_lock_date
+#, fuzzy
+msgid "Management Closing"
+msgstr "Cierre gerencial"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year__name
+#, fuzzy
+msgid "Name"
+msgstr "Nombre"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,help:om_fiscal_year.field_change_lock_date__tax_lock_date
+#, fuzzy
+msgid ""
+"No users can edit journal entries related to a tax prior and inclusive of "
+"this date."
+msgstr ""
+"Ningún usuario puede editar asientos contables relacionados con un impuesto "
+"antes e inclusive de esta fecha."
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,help:om_fiscal_year.field_res_config_settings__fiscalyear_lock_date
+#, fuzzy
+msgid ""
+"No users, including Advisers, can edit accounts prior to and inclusive of "
+"this date. Use it for fiscal year locking for example."
+msgstr ""
+"Ningún usuario, incluyendo Asesores, puede editar cuentas antes de y en "
+"esta fecha. Utilízala, por ejemplo, para bloquear un año fiscal."
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,help:om_fiscal_year.field_change_lock_date__fiscalyear_lock_date
+#, fuzzy
+msgid ""
+"No users, including Advisers, can edit accounts prior to and inclusive of "
+"this date. Use it for fiscal year locking."
+msgstr ""
+"Ningún usuario, incluyendo Asesores, puede editar cuentas antes de y en "
+"esta fecha. Utilízala, por ejemplo, para bloquear un año fiscal."
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,help:om_fiscal_year.field_res_config_settings__period_lock_date
+#, fuzzy
+msgid ""
+"Only users with the 'Adviser' role can edit accounts prior to and inclusive "
+"of this date. Use it for period locking inside an open fiscal year, for "
+"example."
+msgstr ""
+"Sólo los usuarios con el rol 'Asesor' pueden editar cuentas antes de y en "
+"esta fecha. Utilízalo para bloquear un período dentro de un año fiscal "
+"abierto, por ejemplo."
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,help:om_fiscal_year.field_change_lock_date__period_lock_date
+#, fuzzy
+msgid "Prevent posting of journal entries in this period."
+msgstr "Evitar la publicación de entradas de diario en este período."
+
+#. module: om_fiscal_year
+#: model_terms:ir.ui.view,arch_db:om_fiscal_year.view_change_lock_date
+#, fuzzy
+msgid "Save"
+msgstr "Guardar"
+
+#. module: om_fiscal_year
+#. odoo-python
+#: code:addons/om_fiscal_year/models/res_company.py:0
+#, fuzzy, python-format
+msgid "Show unposted entries"
+msgstr "Mostrar asientos no publicados"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_account_fiscal_year__date_from
+#, fuzzy
+msgid "Start Date"
+msgstr "Fecha inicial"
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,help:om_fiscal_year.field_account_fiscal_year__date_from
+#, fuzzy
+msgid "Start Date, included in the fiscal year."
+msgstr "Fecha de inicio, incluida en el año fiscal."
+
+#. module: om_fiscal_year
+#: model:ir.model.fields,field_description:om_fiscal_year.field_change_lock_date__tax_lock_date
+#, fuzzy
+msgid "Tax Lock Date"
+msgstr "Fecha de bloqueo de impuestos"
+
+#. module: om_fiscal_year
+#. odoo-python
+#: code:addons/om_fiscal_year/models/account_fiscal_year.py:0
+#, fuzzy, python-format
+msgid "The ending date must not be prior to the starting date."
+msgstr "La fecha de finalización no debe ser anterior a la fecha de inicio."
+
+#. module: om_fiscal_year
+#. odoo-python
+#: code:addons/om_fiscal_year/models/res_company.py:0
+#, fuzzy, python-format
+msgid ""
+"There are still unposted entries in the period you want to lock. You should "
+"either post or delete them."
+msgstr ""
+"Todavía hay asientos sin validar en el periodo que quieres cerrar. Debes "
+"validarlos o borrarlos."
+
+#. module: om_fiscal_year
+#. odoo-python
+#: code:addons/om_fiscal_year/models/res_company.py:0
+#, fuzzy, python-format
+msgid ""
+"There are still unreconciled bank statement lines in the period you want to "
+"lock.You should either reconcile or delete them."
+msgstr ""
+"Todavía hay líneas de extractos bancarios sin conciliar en el período que "
+"deseas bloquear. Debes conciliarlas o eliminarlas."
+
+#. module: om_fiscal_year
+#. odoo-python
+#: code:addons/om_fiscal_year/wizard/change_lock_date.py:0
+#, fuzzy, python-format
+msgid "You Are Not Allowed To Perform This Operation"
+msgstr "No se le permite realizar esta operación"
+
+#. module: om_fiscal_year
+#. odoo-python
+#: code:addons/om_fiscal_year/models/account_fiscal_year.py:0
+#, fuzzy, python-format
+msgid ""
+"You can not have an overlap between two fiscal years, please correct the "
+"start and/or end dates of your fiscal years."
+msgstr ""
+"No puedes superponer dos años fiscales, corrige las fechas de inicio y/o "
+"cierre de tus años fiscales."

--- a/om_hospital/i18n/es_CR.po
+++ b/om_hospital/i18n/es_CR.po
@@ -1,0 +1,1012 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_hospital
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 21:01+0000\n"
+"PO-Revision-Date: 2023-07-08 15:02-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_hospital
+#. odoo-python
+#: code:addons/om_hospital/models/doctor.py:0
+#, fuzzy, python-format
+msgid "%s (Copy)"
+msgstr "%s (Copia)"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_form
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_form
+#, fuzzy
+msgid "<span class=\"o_stat_text\">Appointments</span>"
+msgstr "<span class=\"o_stat_text\">Citas</span>"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_detail
+#, fuzzy
+msgid ""
+"<span>\n"
+"                                                            <strong>Age:</strong>\n"
+"                                                        </span>"
+msgstr ""
+"<span>\n"
+"                                                            <strong>Edad:</strong>\n"
+"                                                        </span>"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_detail
+#, fuzzy
+msgid ""
+"<span>\n"
+"                                                            <strong>Reference:</strong>\n"
+"                                                        </span>"
+msgstr ""
+"<span>\n"
+"                                                            <strong>Referencia:</strong>\n"
+"                                                        </span>"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_id_card
+#, fuzzy
+msgid ""
+"<span>\n"
+"                                                        <strong>Age:</strong>\n"
+"                                                    </span>"
+msgstr ""
+"<span>\n"
+"                                                        <strong>Edad:</strong>\n"
+"                                                    </span>"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_id_card
+#, fuzzy
+msgid ""
+"<span>\n"
+"                                                        <strong>Reference:</strong>\n"
+"                                                    </span>"
+msgstr ""
+"<span>\n"
+"                                                        <strong>Referencia:</strong>\n"
+"                                                    </span>"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_detail
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_id_card
+#, fuzzy
+msgid "<span>:</span>"
+msgstr "<span class=\"text-nowrap\">$ <span class=\"oe_currency_value\">11.750,00</span></span>"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_detail
+#, fuzzy
+msgid "<span>Age</span>"
+msgstr "<span>Edad</span>"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_detail
+#, fuzzy
+msgid "<span>Appointment Details</span>"
+msgstr "<span>Detalles de la cita</span>"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_detail
+#, fuzzy
+msgid "<span>Doctor</span>"
+msgstr "<span>Doctor</span>"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_detail
+#, fuzzy
+msgid "<span>Reference</span>"
+msgstr "<span>Referencia</span>"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.report_patient_detail
+#, fuzzy
+msgid "<strong>Total Appointments</strong>"
+msgstr "<strong>Total de citas</strong>"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_needaction
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_needaction
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_needaction
+#, fuzzy
+msgid "Action Needed"
+msgstr "Acción necesaria"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__active
+#, fuzzy
+msgid "Active"
+msgstr "Activo"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__activity_ids
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__activity_ids
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__activity_ids
+#, fuzzy
+msgid "Activities"
+msgstr "Actividades"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__activity_exception_decoration
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__activity_exception_decoration
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__activity_exception_decoration
+#, fuzzy
+msgid "Activity Exception Decoration"
+msgstr "Decoración de excepción de actividad"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__activity_state
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__activity_state
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__activity_state
+#, fuzzy
+msgid "Activity State"
+msgstr "Estado de Actividad"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__activity_type_icon
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__activity_type_icon
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__activity_type_icon
+#, fuzzy
+msgid "Activity Type Icon"
+msgstr "Icono de tipo de actividad"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__age
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__age
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__age
+#, fuzzy
+msgid "Age"
+msgstr "Edad"
+
+#. module: om_hospital
+#. odoo-python
+#: code:addons/om_hospital/models/patient.py:0
+#, fuzzy, python-format
+msgid "Age Cannot Be Zero .. !"
+msgstr "La edad no puede ser cero.. !"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_kanban
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_kanban
+#, fuzzy
+msgid "Age:"
+msgstr "Edad:"
+
+#. module: om_hospital
+#. odoo-python
+#: code:addons/om_hospital/wizard/create_appointment.py:0
+#: model:ir.model.fields,field_description:om_hospital.field_appointment_prescription_lines__appointment_id
+#, fuzzy, python-format
+msgid "Appointment"
+msgstr "Cita"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__appointment_count
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__appointment_count
+#, fuzzy
+msgid "Appointment Count"
+msgstr "Número de citas"
+
+#. module: om_hospital
+#: model:ir.model,name:om_hospital.model_appointment_prescription_lines
+#, fuzzy
+msgid "Appointment Prescription Lines"
+msgstr "Líneas de recetas para citas"
+
+#. module: om_hospital
+#: model:ir.actions.act_window,name:om_hospital.action_hospital_appointment
+#: model:ir.actions.act_window,name:om_hospital.action_open_appointments
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__appointment_ids
+#: model:ir.ui.menu,name:om_hospital.menu_appointment
+#: model:ir.ui.menu,name:om_hospital.menu_appointment_root
+#: model:ir.ui.menu,name:om_hospital.menu_sale_appointment
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_form
+#, fuzzy
+msgid "Appointments"
+msgstr "Citas"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_search
+#, fuzzy
+msgid "Archived"
+msgstr "Archivado"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_form
+#, fuzzy
+msgid "Are you sure that you need to cancel ?"
+msgstr "¿Está seguro de que necesita cancelar?"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_form
+#, fuzzy
+msgid "Are you sure that you need to confirm ?"
+msgstr "¿Está seguro de que necesita confirmar?"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_attachment_count
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_attachment_count
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_attachment_count
+#, fuzzy
+msgid "Attachment Count"
+msgstr "Recuento de archivos adjuntos"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_form
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_create_appointment_form
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_search_appointment_form
+#, fuzzy
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: om_hospital
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_appointment__state__cancel
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_patient__state__cancel
+#, fuzzy
+msgid "Cancelled"
+msgstr "Cancelado"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__date_checkup
+#, fuzzy
+msgid "Check Up Time"
+msgstr "Hora de verificación"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_form
+#, fuzzy
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: om_hospital
+#: model:ir.actions.server,name:om_hospital.action_confirm_appointments
+#, fuzzy
+msgid "Confirm Appointment"
+msgstr "Confirmar cita"
+
+#. module: om_hospital
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_appointment__state__confirm
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_patient__state__confirm
+#, fuzzy
+msgid "Confirmed"
+msgstr "Confirmado"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_create_appointment_form
+#, fuzzy
+msgid "Create"
+msgstr "Crear"
+
+#. module: om_hospital
+#: model:ir.actions.act_window,name:om_hospital.action_create_appointment
+#: model:ir.actions.server,name:om_hospital.action_create_appointments
+#: model:ir.ui.menu,name:om_hospital.menu_create_appointment
+#, fuzzy
+msgid "Create Appointment"
+msgstr "Crear cita"
+
+#. module: om_hospital
+#: model:ir.model,name:om_hospital.model_create_appointment_wizard
+#, fuzzy
+msgid "Create Appointment Wizard"
+msgstr "Asistente para crear citas"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_create_appointment_form
+#, fuzzy
+msgid "Create New Appointment"
+msgstr "Crear nueva cita"
+
+#. module: om_hospital
+#: model_terms:ir.actions.act_window,help:om_hospital.action_female_patients
+#, fuzzy
+msgid "Create your female patient !"
+msgstr "¡Crea tu paciente femenina!"
+
+#. module: om_hospital
+#: model_terms:ir.actions.act_window,help:om_hospital.action_hospital_appointment
+#: model_terms:ir.actions.act_window,help:om_hospital.action_open_appointments
+#, fuzzy
+msgid "Create your first appointment !"
+msgstr "¡Crea tu primera cita!"
+
+#. module: om_hospital
+#: model_terms:ir.actions.act_window,help:om_hospital.action_hospital_doctor
+#, fuzzy
+msgid "Create your first doctor!"
+msgstr "¡Crea tu primer médico!"
+
+#. module: om_hospital
+#: model_terms:ir.actions.act_window,help:om_hospital.action_hospital_kids
+#, fuzzy
+msgid "Create your first kids!"
+msgstr "¡Crea tus primeros hijos!"
+
+#. module: om_hospital
+#: model_terms:ir.actions.act_window,help:om_hospital.action_male_patients
+#, fuzzy
+msgid "Create your first male patient!"
+msgstr "¡Crea tu primer paciente masculino!"
+
+#. module: om_hospital
+#: model_terms:ir.actions.act_window,help:om_hospital.action_hospital_patient
+#, fuzzy
+msgid "Create your first patient!"
+msgstr "¡Crea tu primer paciente!"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_appointment_prescription_lines__create_uid
+#: model:ir.model.fields,field_description:om_hospital.field_create_appointment_wizard__create_uid
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__create_uid
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__create_uid
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__create_uid
+#: model:ir.model.fields,field_description:om_hospital.field_search_appointment_wizard__create_uid
+#, fuzzy
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_appointment_prescription_lines__create_date
+#: model:ir.model.fields,field_description:om_hospital.field_create_appointment_wizard__create_date
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__create_date
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__create_date
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__create_date
+#: model:ir.model.fields,field_description:om_hospital.field_search_appointment_wizard__create_date
+#, fuzzy
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_create_appointment_wizard__date_appointment
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__date_appointment
+#, fuzzy
+msgid "Date"
+msgstr "Fecha"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__note
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__note
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__note
+#, fuzzy
+msgid "Description"
+msgstr "Descripción"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_appointment_prescription_lines__display_name
+#: model:ir.model.fields,field_description:om_hospital.field_create_appointment_wizard__display_name
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__display_name
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__display_name
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__display_name
+#: model:ir.model.fields,field_description:om_hospital.field_search_appointment_wizard__display_name
+#, fuzzy
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__doctor_id
+#, fuzzy
+msgid "Doctor"
+msgstr "Doctor"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_form
+#, fuzzy
+msgid "Doctor Prescription"
+msgstr "Prescripción del médico"
+
+#. module: om_hospital
+#: model:ir.actions.act_window,name:om_hospital.action_hospital_doctor
+#: model:ir.ui.menu,name:om_hospital.menu_doctor
+#: model:ir.ui.menu,name:om_hospital.menu_doctor_root
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_search
+#, fuzzy
+msgid "Doctors"
+msgstr "Médicos"
+
+#. module: om_hospital
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_appointment__state__done
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_patient__state__done
+#, fuzzy
+msgid "Done"
+msgstr "Realizado"
+
+#. module: om_hospital
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_appointment__state__draft
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_patient__state__draft
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_search
+#, fuzzy
+msgid "Draft"
+msgstr "Borrador"
+
+#. module: om_hospital
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_appointment__gender__female
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_doctor__gender__female
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_patient__gender__female
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_search
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_search
+#, fuzzy
+msgid "Female"
+msgstr "Mujer"
+
+#. module: om_hospital
+#: model:ir.actions.act_window,name:om_hospital.action_female_patients
+#: model:ir.ui.menu,name:om_hospital.menu_female_patients
+#, fuzzy
+msgid "Female Patients"
+msgstr "Pacientes femeninas"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_follower_ids
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_follower_ids
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_follower_ids
+#, fuzzy
+msgid "Followers"
+msgstr "Seguidores"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_partner_ids
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_partner_ids
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_partner_ids
+#, fuzzy
+msgid "Followers (Partners)"
+msgstr "Seguidores (Socios)"
+
+#. module: om_hospital
+#: model:ir.model.fields,help:om_hospital.field_hospital_appointment__activity_type_icon
+#: model:ir.model.fields,help:om_hospital.field_hospital_doctor__activity_type_icon
+#: model:ir.model.fields,help:om_hospital.field_hospital_patient__activity_type_icon
+#, fuzzy
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr "Icono de Fotn awesome, por ejemplo fa-tasks"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__gender
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__gender
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__gender
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_search
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_search
+#, fuzzy
+msgid "Gender"
+msgstr "Género"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_kanban
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_kanban
+#, fuzzy
+msgid "Gender:"
+msgstr "Género:"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_search
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_search
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_search
+#, fuzzy
+msgid "Group By"
+msgstr "Agrupar por"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__has_message
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__has_message
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__has_message
+#, fuzzy
+msgid "Has Message"
+msgstr "Tiene mensaje"
+
+#. module: om_hospital
+#: model:ir.ui.menu,name:om_hospital.menu_hospital_root
+#, fuzzy
+msgid "Hospital"
+msgstr "Hospital"
+
+#. module: om_hospital
+#: model:ir.model,name:om_hospital.model_hospital_appointment
+#, fuzzy
+msgid "Hospital Appointment"
+msgstr "Cita en el hospital"
+
+#. module: om_hospital
+#: model:ir.model,name:om_hospital.model_hospital_doctor
+#, fuzzy
+msgid "Hospital Doctor"
+msgstr "Médico del Hospital"
+
+#. module: om_hospital
+#: model:ir.model,name:om_hospital.model_hospital_patient
+#, fuzzy
+msgid "Hospital Patient"
+msgstr "Paciente del hospital"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_appointment_prescription_lines__id
+#: model:ir.model.fields,field_description:om_hospital.field_create_appointment_wizard__id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__id
+#: model:ir.model.fields,field_description:om_hospital.field_search_appointment_wizard__id
+#, fuzzy
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_kanban
+#, fuzzy
+msgid "ID:"
+msgstr "ID:"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__activity_exception_icon
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__activity_exception_icon
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__activity_exception_icon
+#, fuzzy
+msgid "Icon"
+msgstr "Icono"
+
+#. module: om_hospital
+#: model:ir.model.fields,help:om_hospital.field_hospital_appointment__activity_exception_icon
+#: model:ir.model.fields,help:om_hospital.field_hospital_doctor__activity_exception_icon
+#: model:ir.model.fields,help:om_hospital.field_hospital_patient__activity_exception_icon
+#, fuzzy
+msgid "Icon to indicate an exception activity."
+msgstr "Icono para indicar una actividad de excepción."
+
+#. module: om_hospital
+#: model:ir.model.fields,help:om_hospital.field_hospital_appointment__message_needaction
+#: model:ir.model.fields,help:om_hospital.field_hospital_doctor__message_needaction
+#: model:ir.model.fields,help:om_hospital.field_hospital_patient__message_needaction
+#, fuzzy
+msgid "If checked, new messages require your attention."
+msgstr "Si está marcado, los nuevos mensajes requieren su atención."
+
+#. module: om_hospital
+#: model:ir.model.fields,help:om_hospital.field_hospital_appointment__message_has_error
+#: model:ir.model.fields,help:om_hospital.field_hospital_appointment__message_has_sms_error
+#: model:ir.model.fields,help:om_hospital.field_hospital_doctor__message_has_error
+#: model:ir.model.fields,help:om_hospital.field_hospital_doctor__message_has_sms_error
+#: model:ir.model.fields,help:om_hospital.field_hospital_patient__message_has_error
+#: model:ir.model.fields,help:om_hospital.field_hospital_patient__message_has_sms_error
+#, fuzzy
+msgid "If checked, some messages have a delivery error."
+msgstr "Si está marcada, algunos mensajes tienen un error de entrega."
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_is_follower
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_is_follower
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_is_follower
+#, fuzzy
+msgid "Is Follower"
+msgstr "Es seguidor"
+
+#. module: om_hospital
+#: model:ir.actions.act_window,name:om_hospital.action_hospital_kids
+#: model:ir.ui.menu,name:om_hospital.menu_kids
+#, fuzzy
+msgid "Kids"
+msgstr "Niños"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_appointment_prescription_lines____last_update
+#: model:ir.model.fields,field_description:om_hospital.field_create_appointment_wizard____last_update
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment____last_update
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor____last_update
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient____last_update
+#: model:ir.model.fields,field_description:om_hospital.field_search_appointment_wizard____last_update
+#, fuzzy
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_appointment_prescription_lines__write_uid
+#: model:ir.model.fields,field_description:om_hospital.field_create_appointment_wizard__write_uid
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__write_uid
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__write_uid
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__write_uid
+#: model:ir.model.fields,field_description:om_hospital.field_search_appointment_wizard__write_uid
+#, fuzzy
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_appointment_prescription_lines__write_date
+#: model:ir.model.fields,field_description:om_hospital.field_create_appointment_wizard__write_date
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__write_date
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__write_date
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__write_date
+#: model:ir.model.fields,field_description:om_hospital.field_search_appointment_wizard__write_date
+#, fuzzy
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_main_attachment_id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_main_attachment_id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_main_attachment_id
+#, fuzzy
+msgid "Main Attachment"
+msgstr "Archivo adjunto principal"
+
+#. module: om_hospital
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_appointment__gender__male
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_doctor__gender__male
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_patient__gender__male
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_search
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_search
+#, fuzzy
+msgid "Male"
+msgstr "Hombre"
+
+#. module: om_hospital
+#: model:ir.actions.act_window,name:om_hospital.action_male_patients
+#: model:ir.ui.menu,name:om_hospital.menu_male_patients
+#, fuzzy
+msgid "Male Patients"
+msgstr "Pacientes masculinos"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_form
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_tree
+#, fuzzy
+msgid "Mark As Done"
+msgstr "⇾ Marcar como hecho"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_appointment_prescription_lines__name
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_form
+#, fuzzy
+msgid "Medicine"
+msgstr "Medicina"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_has_error
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_has_error
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_has_error
+#, fuzzy
+msgid "Message Delivery error"
+msgstr "Error de entrega de mensajes"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_ids
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_ids
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_ids
+#, fuzzy
+msgid "Messages"
+msgstr "Mensajes"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__my_activity_date_deadline
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__my_activity_date_deadline
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__my_activity_date_deadline
+#, fuzzy
+msgid "My Activity Deadline"
+msgstr "Fecha límite de mi actividad"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__doctor_name
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__name
+#, fuzzy
+msgid "Name"
+msgstr "Nombre"
+
+#. module: om_hospital
+#. odoo-python
+#: code:addons/om_hospital/models/patient.py:0
+#, fuzzy, python-format
+msgid "Name %s Already Exists"
+msgstr "Nombre %s ya existe"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_kanban
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_kanban
+#, fuzzy
+msgid "Name:"
+msgstr "Nombre:"
+
+#. module: om_hospital
+#. odoo-python
+#: code:addons/om_hospital/models/appointment.py:0
+#: code:addons/om_hospital/models/patient.py:0
+#, fuzzy, python-format
+msgid "New"
+msgstr "Nuevo"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__activity_calendar_event_id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__activity_calendar_event_id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__activity_calendar_event_id
+#, fuzzy
+msgid "Next Activity Calendar Event"
+msgstr "Siguiente evento del calendario de actividades"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__activity_date_deadline
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__activity_date_deadline
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__activity_date_deadline
+#, fuzzy
+msgid "Next Activity Deadline"
+msgstr "Fecha límite de la próxima actividad"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__activity_summary
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__activity_summary
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__activity_summary
+#, fuzzy
+msgid "Next Activity Summary"
+msgstr "Resumen de la siguiente actividad"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__activity_type_id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__activity_type_id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__activity_type_id
+#, fuzzy
+msgid "Next Activity Type"
+msgstr "Siguiente tipo de actividad"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_needaction_counter
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_needaction_counter
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_needaction_counter
+#, fuzzy
+msgid "Number of Actions"
+msgstr "Número de acciones"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_has_error_counter
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_has_error_counter
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_has_error_counter
+#, fuzzy
+msgid "Number of errors"
+msgstr "Número de errores"
+
+#. module: om_hospital
+#: model:ir.model.fields,help:om_hospital.field_hospital_appointment__message_needaction_counter
+#: model:ir.model.fields,help:om_hospital.field_hospital_doctor__message_needaction_counter
+#: model:ir.model.fields,help:om_hospital.field_hospital_patient__message_needaction_counter
+#, fuzzy
+msgid "Number of messages which requires an action"
+msgstr "Número de mensajes que requieren una acción"
+
+#. module: om_hospital
+#: model:ir.model.fields,help:om_hospital.field_hospital_appointment__message_has_error_counter
+#: model:ir.model.fields,help:om_hospital.field_hospital_doctor__message_has_error_counter
+#: model:ir.model.fields,help:om_hospital.field_hospital_patient__message_has_error_counter
+#, fuzzy
+msgid "Number of messages with delivery error"
+msgstr "Número de mensajes con error de entrega"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_form
+#, fuzzy
+msgid "Open URL"
+msgstr "Abrir URL"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__name
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__reference
+#, fuzzy
+msgid "Order Reference"
+msgstr "Referencia del pedido"
+
+#. module: om_hospital
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_appointment__gender__other
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_doctor__gender__other
+#: model:ir.model.fields.selection,name:om_hospital.selection__hospital_patient__gender__other
+#, fuzzy
+msgid "Other"
+msgstr "Otro"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_form
+#, fuzzy
+msgid "Other Info"
+msgstr "Otra Información"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_doctor_search
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_search
+#, fuzzy
+msgid "Others"
+msgstr "Otros"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_create_appointment_wizard__patient_id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__patient_id
+#: model:ir.model.fields,field_description:om_hospital.field_search_appointment_wizard__patient_id
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_search
+#, fuzzy
+msgid "Patient"
+msgstr "Paciente"
+
+#. module: om_hospital
+#: model:ir.actions.report,name:om_hospital.report_patient_card
+#, fuzzy
+msgid "Patient Card"
+msgstr "Tarjeta de paciente"
+
+#. module: om_hospital
+#: model:ir.actions.report,name:om_hospital.report_patient_details
+#, fuzzy
+msgid "Patient Details"
+msgstr "Detalles del paciente"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__image
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__image
+#, fuzzy
+msgid "Patient Image"
+msgstr "Imagen del paciente"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_search
+#, fuzzy
+msgid "Patient Name"
+msgstr "Nombre del paciente"
+
+#. module: om_hospital
+#: model:ir.actions.act_window,name:om_hospital.action_hospital_patient
+#: model:ir.ui.menu,name:om_hospital.menu_patient
+#: model:ir.ui.menu,name:om_hospital.menu_patient_root
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_search
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_search
+#, fuzzy
+msgid "Patients"
+msgstr "Pacientes"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__prescription
+#, fuzzy
+msgid "Prescription"
+msgstr "Receta"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__prescription_line_ids
+#, fuzzy
+msgid "Prescription Lines"
+msgstr "Líneas de prescripción"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_appointment_prescription_lines__qty
+#, fuzzy
+msgid "Quantity"
+msgstr "Cantidad"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__responsible_id
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_patient_search
+#, fuzzy
+msgid "Responsible"
+msgstr "Responsable"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__activity_user_id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__activity_user_id
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__activity_user_id
+#, fuzzy
+msgid "Responsible User"
+msgstr "Usuario responsable"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__message_has_sms_error
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__message_has_sms_error
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__message_has_sms_error
+#, fuzzy
+msgid "SMS Delivery error"
+msgstr "Error de entrega de SMS"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_sale_order__sale_description
+#, fuzzy
+msgid "Sale Description"
+msgstr "Descripción de la venta"
+
+#. module: om_hospital
+#: model:ir.model,name:om_hospital.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: om_hospital
+#: model:ir.ui.menu,name:om_hospital.menu_search_appointment
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_search_appointment_form
+#, fuzzy
+msgid "Search Appointment"
+msgstr "Buscar cita"
+
+#. module: om_hospital
+#: model:ir.model,name:om_hospital.model_search_appointment_wizard
+#, fuzzy
+msgid "Search Appointment Wizard"
+msgstr "Asistente para buscar citas"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_search_appointment_form
+#, fuzzy
+msgid "Search Appointments (M1)"
+msgstr "Buscar citas (M1)"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_search_appointment_form
+#, fuzzy
+msgid "Search Appointments (M2)"
+msgstr "Buscar citas (M2)"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_search_appointment_form
+#, fuzzy
+msgid "Search Appointments (M3)"
+msgstr "Buscar citas (M3)"
+
+#. module: om_hospital
+#: model_terms:ir.ui.view,arch_db:om_hospital.view_appointment_form
+#, fuzzy
+msgid "Set To Draft"
+msgstr "Restablecer a borrador"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__state
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__state
+#, fuzzy
+msgid "Status"
+msgstr "Estado"
+
+#. module: om_hospital
+#: model:ir.model.fields,help:om_hospital.field_hospital_appointment__activity_state
+#: model:ir.model.fields,help:om_hospital.field_hospital_doctor__activity_state
+#: model:ir.model.fields,help:om_hospital.field_hospital_patient__activity_state
+#, fuzzy
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+"Estado basado en actividades\n"
+"Atrasado: la fecha de vencimiento ya pasó\n"
+"Hoy: la fecha de la actividad es hoy\n"
+"Planificado: Actividades futuras."
+
+#. module: om_hospital
+#: model:ir.model.fields,help:om_hospital.field_hospital_appointment__activity_exception_decoration
+#: model:ir.model.fields,help:om_hospital.field_hospital_doctor__activity_exception_decoration
+#: model:ir.model.fields,help:om_hospital.field_hospital_patient__activity_exception_decoration
+#, fuzzy
+msgid "Type of the exception activity on record."
+msgstr "Tipo de actividad de excepción registrada."
+
+#. module: om_hospital
+#: model:ir.actions.act_window,name:om_hospital.action_search_appointment
+#, fuzzy
+msgid "View Appointment"
+msgstr "Ver cita"
+
+#. module: om_hospital
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_appointment__website_message_ids
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_doctor__website_message_ids
+#: model:ir.model.fields,field_description:om_hospital.field_hospital_patient__website_message_ids
+#, fuzzy
+msgid "Website Messages"
+msgstr "Mensajes del sitio web"
+
+#. module: om_hospital
+#: model:ir.model.fields,help:om_hospital.field_hospital_appointment__website_message_ids
+#: model:ir.model.fields,help:om_hospital.field_hospital_doctor__website_message_ids
+#: model:ir.model.fields,help:om_hospital.field_hospital_patient__website_message_ids
+#, fuzzy
+msgid "Website communication history"
+msgstr "Historial de comunicación del sitio web"
+
+#. module: om_hospital
+#. odoo-python
+#: code:addons/om_hospital/models/appointment.py:0
+#, fuzzy, python-format
+msgid "You Cannot Delete %s as it is in Done State"
+msgstr "No puede eliminar %s ya que está en estado Listo"

--- a/om_hr_payroll/i18n/es_CR.po
+++ b/om_hr_payroll/i18n/es_CR.po
@@ -1,31 +1,78 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * om_hr_payroll
-# 
-# Translators:
-# Martin Trigaux <mat@odoo.com>, 2017
+# 	* om_hr_payroll
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-30 13:11+0000\n"
-"PO-Revision-Date: 2017-11-30 13:11+0000\n"
-"Last-Translator: Martin Trigaux <mat@odoo.com>, 2017\n"
-"Language-Team: Spanish (Costa Rica) (https://www.transifex.com/odoo/teams/41243/es_CR/)\n"
+"POT-Creation-Date: 2023-07-08 21:03+0000\n"
+"PO-Revision-Date: 2023-07-08 15:05-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Language: es_CR\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_salary_rule.py:41
-#, python-format
-msgid "%s (copy)"
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_salary_rule.py:0
+#, fuzzy, python-format
+msgid ""
+"\n"
+"                        Wrong python code defined for salary rule %s (%s).\n"
+"                        Here is the error received:\n"
+"                        %s\n"
+"                        "
 msgstr ""
+"\n"
+"Código de Python incorrecto definido para la regla de salario %s (%s).\n"
+"                        Aquí está el error recibido:\n"
+"                        %s\n"
+"                        "
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_state
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_salary_rule.py:0
+#, fuzzy, python-format
+msgid ""
+"\n"
+"                        Wrong python condition defined for salary rule %s "
+"(%s).\n"
+"                        Here is the error received:\n"
+"                        %s\n"
+"                        "
+msgstr ""
+"\n"
+"Condición de pitón incorrecta definida para la regla salarial %s (%s).\n"
+"                        Aquí está el error recibido:\n"
+"                        %s\n"
+"                        "
+
+#. module: om_hr_payroll
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_salary_rule.py:0
+#, fuzzy, python-format
+msgid "%s (copy)"
+msgstr "%s (copia)"
+
+#. module: om_hr_payroll
+#: model:ir.actions.report,print_report_name:om_hr_payroll.action_report_payslip
+#, fuzzy
+msgid "('Payslip - %s' % (object.employee_id.name))"
+msgstr "(«Nómina - %s» % (object.employee_id.nombre))"
+
+#. module: om_hr_payroll
+#: model:ir.actions.report,print_report_name:om_hr_payroll.payslip_details_report
+#, fuzzy
+msgid "('Payslip Details - %s' % (object.employee_id.name))"
+msgstr "(«Datos de la nómina - %s» % (object.employee_id.nombre))"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__state
 msgid ""
 "* When the payslip is created the status is 'Draft'\n"
 "                \n"
@@ -35,187 +82,311 @@ msgid ""
 "                \n"
 "* When user cancel payslip the status is 'Rejected'."
 msgstr ""
+"* Cuando la nómina es creada el estado es 'Borrador'\n"
+"                \n"
+"* Si la nómina está bajo verificación el estado es 'En Espera'.\n"
+"                \n"
+"* Si la nómina está confirmada entonces el estado se cambia a "
+"'Finalizado'.\n"
+"                \n"
+"* Cuando el usuario cancela la nómina el estado es 'Rechazado'."
+
+#. module: om_hr_payroll
+#: model:mail.template,body_html:om_hr_payroll.mail_template_payslip
+#, fuzzy
+msgid ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                    <p> Dear <t t-out=\"object.employee_id.name or ''\"></"
+"t>,</p>\n"
+"                    <p>Please find the attached payslip of the period: <t t-"
+"out=\"object.date_from\"></t> - <t t-out=\"object.date_to\"></t></p>\n"
+"                    <p>In case of any queries concerning this matter, do "
+"not hesitate to contact our accounting/hr department.</p>\n"
+"                    <br>\n"
+"                    Best Regards,\n"
+"                    <br>\n"
+"                    <t t-out=\"user.name\"></t>\n"
+"                    <br>\n"
+"                </div>\n"
+"            "
+msgstr ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                    <p> Estimado <t t-out=\"object.employee_id.name or "
+"''\"></t>,</p>\n"
+"                    <p>Por favor, encuentre la nómina adjunta del período: "
+"<t t-out=\"object.date_from\"></t> - <t t-out=\"object.date_to\"></t></p>\n"
+"                    <p>En caso de cualquier consulta relacionada con este "
+"asunto, no dude en ponerse en contacto con nuestro departamento de "
+"contabilidad / recursos humanos.</p>\n"
+"                    <br>Saludos                    <br>\n"
+"                    <t t-out=\"user.name\"></t>\n"
+"                    <br>\n"
+"                </div>\n"
+"            "
+
+#. module: om_hr_payroll
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_by_employees
+#, fuzzy
+msgid ""
+"<span colspan=\"4\" nolabel=\"1\">This wizard will generate payslips for "
+"all selected employee(s) based\n"
+"                        on the dates and credit note specified on Payslips "
+"Run.\n"
+"                    </span>"
+msgstr ""
+"<span colspan=\"4\" nolabel=\"1\">Este asistente generará recibos de pago "
+"para todos los empleados seleccionados en función de\n"
+"                        en las fechas y notas de crédito especificadas en "
+"Payslips Run.                    </span>"
+
+#. module: om_hr_payroll
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_contract_form_inherit
+#, fuzzy
+msgid "<span>/ month</span>"
+msgstr "<span>/mes</span>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "<strong>Address</strong>"
-msgstr ""
+msgstr "<strong>Dirección</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "<strong>Authorized signature</strong>"
-msgstr ""
+msgstr "<strong>Firma autorizada</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "<strong>Bank Account</strong>"
-msgstr ""
+msgstr "<strong>Cuenta bancaria</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
 msgid "<strong>Date From:</strong>"
-msgstr ""
+msgstr "<strong>Fecha desde:</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "<strong>Date From</strong>"
-msgstr ""
+msgstr "<strong>Fecha desde:</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
 msgid "<strong>Date To:</strong>"
-msgstr ""
+msgstr "<strong>Fecha hasta:</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "<strong>Date To</strong>"
-msgstr ""
+msgstr "<strong>Fecha hasta:</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "<strong>Designation</strong>"
-msgstr ""
+msgstr "<strong>Designación</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
+#, fuzzy
 msgid "<strong>Email</strong>"
-msgstr ""
+msgstr "<strong>Correo electrónico</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "<strong>Identification No</strong>"
-msgstr ""
+msgstr "<strong>Nº identificación</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "<strong>Name</strong>"
-msgstr ""
+msgstr "<strong>Nombre</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "<strong>Reference</strong>"
-msgstr ""
+msgstr "<strong>Referencia</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
 msgid "<strong>Register Name:</strong>"
-msgstr ""
+msgstr "<strong>Nombre Registrado:</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
+#, fuzzy
 msgid "<strong>Total</strong>"
-msgstr ""
+msgstr "<strong>Total</strong>"
 
 #. module: om_hr_payroll
 #: model_terms:ir.actions.act_window,help:om_hr_payroll.action_contribution_register_form
+#, fuzzy
 msgid ""
 "A contribution register is a third party involved in the salary\n"
-"            payment of the employees. It can be the social security, the\n"
-"            estate or anyone that collect or inject money on payslips."
+"                payment of the employees. It can be the social security, "
+"the\n"
+"                state or anyone that collect or inject money on payslips."
 msgstr ""
+"Un registro de cotización es un tercero involucrado en el salario\n"
+"                Pago de los empleados. Puede ser la seguridad social, el\n"
+"                estado o cualquier persona que recaude o inyecte dinero en "
+"las nóminas."
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.res_config_settings_view_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Accounting"
-msgstr ""
+msgstr "Contabilidad"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Accounting Information"
-msgstr ""
+msgstr "Información contable"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_active
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_active
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_needaction
+#, fuzzy
+msgid "Action Needed"
+msgstr "Acción necesaria"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__active
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__active
 msgid "Active"
-msgstr ""
+msgstr "Activo"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__activity_ids
+#, fuzzy
+msgid "Activities"
+msgstr "Actividades"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__activity_exception_decoration
+#, fuzzy
+msgid "Activity Exception Decoration"
+msgstr "Decoración de excepción de actividad"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__activity_state
+#, fuzzy
+msgid "Activity State"
+msgstr "Estado de Actividad"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__activity_type_icon
+#, fuzzy
+msgid "Activity Type Icon"
+msgstr "Icono de tipo de actividad"
+
+#. module: om_hr_payroll
+#: model_terms:ir.actions.act_window,help:om_hr_payroll.action_contribution_register_form
+#, fuzzy
+msgid "Add a new contribution register"
+msgstr "Agregar un nuevo registro de contribuciones"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Add an internal note..."
-msgstr ""
+msgstr "Añadir una nota interna..."
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_contract_advantage_template_view_form
 msgid "Advantage Name"
-msgstr ""
+msgstr "Nombre de ventaja"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.act_children_salary_rules
 msgid "All Children Rules"
-msgstr ""
+msgstr "Todas las reglas hijas"
 
 #. module: om_hr_payroll
-#: selection:hr.payslip.line,condition_select:0
-#: selection:hr.salary.rule,condition_select:0
+#: model:hr.salary.rule.category,name:om_hr_payroll.ALW
+msgid "Allowance"
+msgstr "Prima"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip_line__condition_select__none
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_salary_rule__condition_select__none
 msgid "Always True"
-msgstr ""
+msgstr "Siempre verdadero"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_amount
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_amount
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__amount
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__amount
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "Amount"
-msgstr ""
+msgstr "Importe"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_amount_select
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_amount_select
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__amount_select
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__amount_select
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_line_filter
 msgid "Amount Type"
-msgstr ""
+msgstr "Tipo de importe"
 
 #. module: om_hr_payroll
-#: selection:hr.contract,schedule_pay:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_contract__schedule_pay__annually
 msgid "Annually"
-msgstr ""
+msgstr "Anualmente"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_appears_on_payslip
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_appears_on_payslip
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__appears_on_payslip
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__appears_on_payslip
 msgid "Appears on Payslip"
-msgstr ""
+msgstr "Aparece en la nómina"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_condition_python
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_condition_python
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__condition_python
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__condition_python
 msgid ""
 "Applied this rule for calculation if condition is true. You can specify "
 "condition like basic > 1000."
 msgstr ""
+"Se utiliza esta regla para el cálculo si la condición es verdadera. Puede "
+"especificar una condición como: 'basic > 1000'."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_res_config_settings_module_l10n_be_hr_payroll
-msgid "Belgium Payroll"
-msgstr ""
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_attachment_count
+#, fuzzy
+msgid "Attachment Count"
+msgstr "Recuento de archivos adjuntos"
 
 #. module: om_hr_payroll
-#: selection:hr.contract,schedule_pay:0
+#: model:hr.salary.rule.category,name:om_hr_payroll.BASIC
+msgid "Basic"
+msgstr "Básico"
+
+#. module: om_hr_payroll
+#: model:hr.salary.rule,name:om_hr_payroll.hr_rule_basic
+msgid "Basic Salary"
+msgstr "Salario básico total"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_contract__schedule_pay__bi-monthly
 msgid "Bi-monthly"
-msgstr ""
+msgstr "Bimensual"
 
 #. module: om_hr_payroll
-#: selection:hr.contract,schedule_pay:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_contract__schedule_pay__bi-weekly
 msgid "Bi-weekly"
-msgstr ""
+msgstr "Bisemanal"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_line_form
 msgid "Calculations"
-msgstr ""
+msgstr "Cálculos"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_payslip_lines_contribution_register
@@ -225,78 +396,63 @@ msgstr "Cancelar"
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Cancel Payslip"
-msgstr ""
+msgstr "Cancelar nómina"
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_payslip.py:98
-#, python-format
-msgid "Cannot cancel a payslip that is done."
-msgstr ""
-
-#. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_category_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_id_7804
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__category_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__category_id
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_rule_filter
 msgid "Category"
-msgstr ""
+msgstr "Categoría"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_form
 msgid "Child Rules"
-msgstr ""
+msgstr "Reglas hijas"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_child_ids
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_child_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__child_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__child_ids
 msgid "Child Salary Rule"
-msgstr ""
+msgstr "Regla salarial hija"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_children_ids
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_children_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__children_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__children_ids
 msgid "Children"
-msgstr ""
+msgstr "Hijos"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_form
 msgid "Children Definition"
-msgstr ""
+msgstr "Definición de los hijos"
 
 #. module: om_hr_payroll
-#: model_terms:ir.ui.view,arch_db:om_hr_payroll.res_config_settings_view_form
-msgid "Choose a Payroll Localization"
-msgstr ""
-
-#. module: om_hr_payroll
-#: model_terms:ir.actions.act_window,help:om_hr_payroll.action_contribution_register_form
-msgid "Click to add a new contribution register."
-msgstr ""
-
-#. module: om_hr_payroll
-#: selection:hr.payslip.run,state:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip_run__state__close
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_form
 msgid "Close"
-msgstr ""
+msgstr "Cerrar"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_code
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_code
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_code
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_code
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input_code
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_code
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_code
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__code
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_leave_type__code
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__code
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__code
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__code
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input__code
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__code
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__code
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "Code"
-msgstr ""
+msgstr "Código"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payroll_structure_view_kanban
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_view_kanban
 msgid "Code:"
-msgstr ""
+msgstr "Código:"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
@@ -304,82 +460,114 @@ msgid "Companies"
 msgstr "Compañías"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_company_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_company_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_company_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_company_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_company_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_company_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__company_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__company_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__company_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__company_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__company_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__company_id
 msgid "Company"
 msgstr "Compañía"
 
 #. module: om_hr_payroll
+#: model:hr.salary.rule.category,name:om_hr_payroll.COMP
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_form
 msgid "Company Contribution"
-msgstr ""
+msgstr "Contribución compañía"
+
+#. module: om_hr_payroll
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
+#, fuzzy, python-format
+msgid "Compose Email"
+msgstr "Redactar correo electrónico"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_form
 msgid "Computation"
-msgstr ""
+msgstr "Cálculo"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Compute Sheet"
-msgstr ""
+msgstr "Calcular hoja"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_condition_select
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_condition_select
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__condition_select
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__condition_select
 msgid "Condition Based on"
-msgstr ""
+msgstr "Condición basada en"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_form
 msgid "Conditions"
-msgstr ""
+msgstr "Condiciones"
+
+#. module: om_hr_payroll
+#: model:ir.model,name:om_hr_payroll.model_res_config_settings
+msgid "Config Settings"
+msgstr "Opciones de configuración"
 
 #. module: om_hr_payroll
 #: model:ir.ui.menu,name:om_hr_payroll.menu_hr_payroll_configuration
 msgid "Configuration"
-msgstr ""
+msgstr "Configuración"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Confirm"
-msgstr ""
+msgstr "Confirmar"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_contract_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_contract_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_contract_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_contract_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__contract_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__contract_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__contract_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__contract_id
 msgid "Contract"
-msgstr ""
+msgstr "Contrato"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.hr_contract_advantage_template_action
 #: model:ir.ui.menu,name:om_hr_payroll.hr_contract_advantage_template_menu_action
 msgid "Contract Advantage Templates"
-msgstr ""
+msgstr "Plantillas de ventaja de contrato"
+
+#. module: om_hr_payroll
+#: model:ir.model,name:om_hr_payroll.model_hr_contract_type
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_contract_type_form
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_contract_type_search
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_contract_type_tree
+msgid "Contract Type"
+msgstr "Tipo de contrato"
+
+#. module: om_hr_payroll
+#: model:ir.actions.act_window,name:om_hr_payroll.action_hr_contract_type
+#: model:ir.ui.menu,name:om_hr_payroll.menu_contract_type
+msgid "Contract Types"
+msgstr "Tipos de contratos"
+
+#. module: om_hr_payroll
+#: model:ir.ui.menu,name:om_hr_payroll.hr_menu_contract
+msgid "Contracts"
+msgstr "Contratos"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_contribution_register_form
 msgid "Contribution"
-msgstr ""
+msgstr "Contribución"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_contribution_register
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_register_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_register_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__register_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__register_id
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_line_filter
 msgid "Contribution Register"
-msgstr ""
+msgstr "Registro de contribución"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_payslip_lines_contribution_register
 msgid "Contribution Register's Payslip Lines"
-msgstr ""
+msgstr "Líneas de la nómina para el registro de contribución"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.action_contribution_register_form
@@ -387,90 +575,118 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_contribution_register_filter
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_contribution_register_tree
 msgid "Contribution Registers"
-msgstr ""
+msgstr "Registros de contribución"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_create_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register_create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_type__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__create_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register__create_uid
 msgid "Created by"
-msgstr ""
+msgstr "Creado por"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_create_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register_create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_type__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__create_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register__create_date
 msgid "Created on"
-msgstr "Creado en"
+msgstr "Creado el"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_credit_note
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_credit_note
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__credit_note
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__credit_note
 msgid "Credit Note"
-msgstr ""
+msgstr "Factura rectificativa"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_date_from
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_date_start
-#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register_date_from
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract__da
+#, fuzzy
+msgid "DA"
+msgstr "DA"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__date_from
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__date_start
+#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register__date_from
 msgid "Date From"
-msgstr ""
+msgstr "Fecha desde"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_date_to
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_date_end
-#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register_date_to
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__date_to
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__date_end
+#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register__date_to
 msgid "Date To"
-msgstr ""
+msgstr "Fecha hasta"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_default_value
+#: model:hr.salary.rule,name:om_hr_payroll.hr_rule_da
+#: model:hr.salary.rule.category,name:om_hr_payroll.DA
+msgid "Dearness Allowance"
+msgstr "Bono por carestía de vida"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract__da
+msgid "Dearness allowance"
+msgstr "Bono por carestía de vida"
+
+#. module: om_hr_payroll
+#: model:hr.salary.rule.category,name:om_hr_payroll.DED
+msgid "Deduction"
+msgstr "Deducción"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__default_value
 msgid "Default value for this advantage"
-msgstr ""
+msgstr "Valor predeterminado para esta ventaja"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract_schedule_pay
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract__schedule_pay
 msgid "Defines the frequency of the wage payment."
-msgstr ""
+msgstr "Defina la frecuencia del pago de salario."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_struct_id
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__struct_id
 msgid ""
 "Defines the rules that have to be applied to this payslip, accordingly to "
 "the contract chosen. If you let empty the field contract, this field isn't "
 "mandatory anymore and thus the rules applied will be all the rules set on "
 "the structure of all contracts of the employee valid for the chosen period"
 msgstr ""
+"Define las reglas que serán aplicadas a esta nómina, de acuerdo con el "
+"contrato escogido. Si deja vacío el campo contrato, este campo no será "
+"obligatorio y por tanto se aplicarán las reglas válidas establecidas en "
+"todos los contratos de empleado para el periodo elegido"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_note
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_note
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_note
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_note
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_note
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__note
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__note
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__note
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input__name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__note
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__note
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_contribution_register_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_form
 msgid "Description"
@@ -479,162 +695,225 @@ msgstr "Descripción"
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Details By Salary Rule Category"
-msgstr ""
+msgstr "Detalles por categoría de regla salarial"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_details_by_salary_rule_category
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__details_by_salary_rule_category
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "Details by Salary Rule Category"
-msgstr ""
+msgstr "Detalles por categoría de regla salarial"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_report_hr_payroll_report_contribution_register_display_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_report_hr_payroll_report_payslip_details_display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_type__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__display_name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Nombre a mostrar"
 
 #. module: om_hr_payroll
-#: selection:hr.payslip,state:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip__state__done
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip_run__state__done
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_filter
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
 msgid "Done"
-msgstr ""
+msgstr "Hecho"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_filter
 msgid "Done Payslip Batches"
-msgstr ""
+msgstr "Procesamientos de nóminas realizados"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
 msgid "Done Slip"
-msgstr ""
+msgstr "Nóminas realizadas"
 
 #. module: om_hr_payroll
-#: selection:hr.payslip,state:0 selection:hr.payslip.run,state:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip__state__draft
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip_run__state__draft
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_filter
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
 msgid "Draft"
-msgstr ""
+msgstr "Borrador"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_filter
 msgid "Draft Payslip Batches"
-msgstr ""
+msgstr "Procesamientos de nóminas borrador"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
 msgid "Draft Slip"
-msgstr ""
+msgstr "Nómina borrador"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_employee
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employee_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_employee_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__employee_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__employee_id
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Employee"
-msgstr ""
+msgstr "Empleado"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract__type_id
+msgid "Employee Category"
+msgstr "Categoría de empleado"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_contract
 msgid "Employee Contract"
-msgstr ""
+msgstr "Contrato de empleado"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_employee_grade_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payroll_structure_list_view
 msgid "Employee Function"
-msgstr ""
+msgstr "Función del empleado"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.action_view_hr_payslip_form
 #: model:ir.ui.menu,name:om_hr_payroll.menu_department_tree
 msgid "Employee Payslips"
-msgstr ""
+msgstr "Nóminas del empleado"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract__type_id
+msgid "Employee category"
+msgstr "Categoría de empleado"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_contract_advantage_template
 msgid "Employee's Advantage on Contract"
-msgstr ""
+msgstr "Ventaja del empleado en el contrato"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees_employee_ids
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract__resource_calendar_id
+msgid "Employee's working schedule."
+msgstr "Plan de trabajo del empleado."
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees__employee_ids
+#: model:ir.ui.menu,name:om_hr_payroll.menu_hr_employee
+#: model:ir.ui.menu,name:om_hr_payroll.menu_payroll_employee
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_by_employees
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_line_filter
 msgid "Employees"
-msgstr ""
+msgstr "Empleados"
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_salary_rule.py:36
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_salary_rule.py:0
 #, python-format
-msgid "Error ! You cannot create a recursive Salary Structure."
+msgid "Error! You cannot create recursive hierarchy of Salary Rule Category."
 msgstr ""
+"Error! No puede crear una jerarquía recursiva de la Categoría Regla "
+"Salarial."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_register_id
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_register_id
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_salary_rule.py:0
+#, python-format
+msgid "Error! You cannot create recursive hierarchy of Salary Rules."
+msgstr "Error! No puede crear una jerarquía recursiva de Regla Salarial."
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__register_id
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__register_id
 msgid "Eventual third party involved in the salary payment of the employees."
 msgstr ""
+"Empresa externa eventual involucrada en el pago de salarios de los "
+"empleados."
 
 #. module: om_hr_payroll
-#: selection:hr.payslip.line,amount_select:0
-#: selection:hr.salary.rule,amount_select:0
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_amount_fix
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_amount_fix
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__amount_fix
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__amount_fix
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip_line__amount_select__fix
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_salary_rule__amount_select__fix
 msgid "Fixed Amount"
-msgstr ""
+msgstr "Importe fijo"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_amount_percentage
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_amount_percentage
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_follower_ids
+#, fuzzy
+msgid "Followers"
+msgstr "Seguidores"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_partner_ids
+#, fuzzy
+msgid "Followers (Partners)"
+msgstr "Seguidores (Socios)"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__activity_type_icon
+#, fuzzy
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr "Icono de Fotn awesome, por ejemplo fa-tasks"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__amount_percentage
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__amount_percentage
 msgid "For example, enter 50.0 to apply a percentage of 50%"
-msgstr ""
+msgstr "Por ejemplo, introduzca 50.0 para aplicar un porcentaje de 50%"
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/report/report_contribution_register.py:34
+#. odoo-python
+#: code:addons/om_hr_payroll/report/report_contribution_register.py:0
 #, python-format
 msgid "Form content is missing, this report cannot be printed."
-msgstr ""
-
-#. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_res_config_settings_module_l10n_fr_hr_payroll
-msgid "French Payroll"
-msgstr ""
+msgstr "Falta el contenido del formulario, este informe no se puede imprimir."
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_form
+#, fuzzy
 msgid "General"
-msgstr ""
+msgstr "General"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_by_employees
 msgid "Generate"
-msgstr ""
+msgstr "Generar"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.action_hr_payslip_by_employees
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_form
 msgid "Generate Payslips"
-msgstr ""
+msgstr "Generar nóminas"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_payslip_employees
 msgid "Generate payslips for all selected employees"
-msgstr ""
+msgstr "Generar las nóminas para todos los empleados seleccionados"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract_type__sequence
+msgid "Gives the sequence when displaying a list of Contract."
+msgstr "Debe dar la secuencia al mostrar una lista de Contrato."
+
+#. module: om_hr_payroll
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
+#, python-format
+msgid "Global Leaves"
+msgstr "Permisos globales"
+
+#. module: om_hr_payroll
+#: model:hr.salary.rule,name:om_hr_payroll.hr_rule_taxable
+#: model:hr.salary.rule.category,name:om_hr_payroll.GROSS
+msgid "Gross"
+msgstr "Bruto"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
@@ -644,405 +923,650 @@ msgid "Group By"
 msgstr "Agrupar por"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_report_hr_payroll_report_contribution_register_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_report_hr_payroll_report_payslip_details_id
-msgid "ID"
-msgstr "ID"
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.res_config_settings_view_form
+#, fuzzy
+msgid "HR Payroll Accounting"
+msgstr "Contabilidad de nómina de recursos humanos"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_run_credit_note
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract__hra
+#, fuzzy
+msgid "HRA"
+msgstr "HRA"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__has_message
+#, fuzzy
+msgid "Has Message"
+msgstr "Tiene mensaje"
+
+#. module: om_hr_payroll
+#: model:hr.salary.rule,name:om_hr_payroll.hr_rule_hra
+#: model:hr.salary.rule.category,name:om_hr_payroll.HRA
+msgid "House Rent Allowance"
+msgstr "Bono por alquiler de casa"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract__hra
+msgid "House rent allowance."
+msgstr "Bono por alquiler de casa."
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_type__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register__id
+#, fuzzy
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__activity_exception_icon
+#, fuzzy
+msgid "Icon"
+msgstr "Icono"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__activity_exception_icon
+#, fuzzy
+msgid "Icon to indicate an exception activity."
+msgstr "Icono para indicar una actividad de excepción."
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__message_needaction
+#, fuzzy
+msgid "If checked, new messages require your attention."
+msgstr "Si está marcado, los nuevos mensajes requieren su atención."
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__message_has_error
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__message_has_sms_error
+#, fuzzy
+msgid "If checked, some messages have a delivery error."
+msgstr "Si está marcada, algunos mensajes tienen un error de entrega."
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_run__credit_note
 msgid ""
 "If its checked, indicates that all payslips generated from here are refund "
 "payslips."
 msgstr ""
+"Si está marcada, indica que todas las nóminas generadas desde aquí son "
+"nóminas reembolso."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_active
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_active
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__active
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__active
 msgid ""
 "If the active field is set to false, it will allow you to hide the salary "
 "rule without removing it."
 msgstr ""
+"Si el campo activo se establece a falso, se puede ocultar la regla salarial "
+"sin eliminarla."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_res_config_settings_module_l10n_in_hr_payroll
-msgid "Indian Payroll"
-msgstr ""
-
-#. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_credit_note
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__credit_note
 msgid "Indicates this payslip has a refund of another"
-msgstr ""
+msgstr "Indica que esta nómina incluye una factura rectificativa de otra"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Input Data"
-msgstr ""
+msgstr "Datos de entrada"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_input_ids
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_input_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__input_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__input_ids
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_form
 msgid "Inputs"
-msgstr ""
+msgstr "Entradas"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_note
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__note
 msgid "Internal Note"
-msgstr ""
+msgstr "Nota interna"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_is_follower
+#, fuzzy
+msgid "Is Follower"
+msgstr "Es seguidor"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_view_kanban
 msgid "Is a Blocking Reason?"
-msgstr ""
+msgstr "¿Es una razón para el bloqueo?"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_quantity
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__quantity
 msgid ""
 "It is used in computation for percentage and fixed amount. For e.g. A rule "
 "for Meal Voucher having fixed amount of 1€ per worked day can have its "
 "quantity defined in expression like worked_days.WORK100.number_of_days."
 msgstr ""
+"Es usada para calcular el porcentaje y la cantidad fija, por ejemplo, un "
+"vale de alimentos con una cantidad fija de 1€ por día trabajado puede tener "
+"una cantidad definida en la expresión como worked_days.WORK100."
+"number_of_days."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_input_amount
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_input__amount
 msgid ""
-"It is used in computation. For e.g. A rule for sales having 1% commission of"
-" basic salary for per product can defined in expression like result = "
+"It is used in computation. For e.g. A rule for sales having 1% commission "
+"of basic salary for per product can defined in expression like result = "
 "inputs.SALEURO.amount * contract.wage*0.01."
 msgstr ""
+"Se usa en el cálculo. Por ejemplo, una regla para ventas con un 1% de "
+"comisión del salario básico para cada producto puede ser definida con una "
+"expresión como 'result = inputs.SALEURO.amount * contract.wage*0.01'."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_report_hr_payroll_report_contribution_register___last_update
-#: model:ir.model.fields,field_description:om_hr_payroll.field_report_hr_payroll_report_payslip_details___last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_type____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category____last_update
+#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register____last_update
 msgid "Last Modified on"
-msgstr ""
+msgstr "Última modificación en"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_write_uid
-#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register_write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_type__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__write_uid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register__write_uid
 msgid "Last Updated by"
-msgstr ""
+msgstr "Última actualización por"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_write_date
-#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register_write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_type__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_employees__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__write_date
+#: model:ir.model.fields,field_description:om_hr_payroll.field_payslip_lines_contribution_register__write_date
 msgid "Last Updated on"
-msgstr ""
+msgstr "Última actualización el"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_category_parent_id
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_category__parent_id
 msgid ""
 "Linking a salary category to its parent is used only for the reporting "
 "purpose."
 msgstr ""
+"Enlazar una categoría salarial con su padre se usa sólo para los informes."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_lower_bound
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__lower_bound
 msgid "Lower Bound"
-msgstr ""
+msgstr "Límite inferior"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract_advantage_template_lower_bound
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract_advantage_template__lower_bound
 msgid "Lower bound authorized by the employer for this advantage"
-msgstr ""
+msgstr "Límite inferior autorizado por el empleado para esta ventaja"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_paid
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__paid
 msgid "Made Payment Order ? "
-msgstr ""
+msgstr "¿Realizar orden de pago? "
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_main_attachment_id
+#, fuzzy
+msgid "Main Attachment"
+msgstr "Archivo adjunto principal"
 
 #. module: om_hr_payroll
 #: model:res.groups,name:om_hr_payroll.group_hr_payroll_manager
 msgid "Manager"
-msgstr ""
+msgstr "Responsable"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_condition_range_max
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_condition_range_max
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_form
+msgid "Mark As Done"
+msgstr "Marcar como echo"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__condition_range_max
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__condition_range_max
 msgid "Maximum Range"
-msgstr ""
+msgstr "Intervalo máximo"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_condition_range_min
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_condition_range_min
+#: model:hr.salary.rule,name:om_hr_payroll.hr_rule_meal
+#: model:hr.salary.rule.category,name:om_hr_payroll.Meal
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract__meal_allowance
+msgid "Meal Allowance"
+msgstr "Bono de comida"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract__meal_allowance
+msgid "Meal allowance"
+msgstr "Meal Allowance"
+
+#. module: om_hr_payroll
+#: model:hr.salary.rule,name:om_hr_payroll.hr_rule_medical
+#: model:hr.salary.rule.category,name:om_hr_payroll.Medical
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract__medical_allowance
+msgid "Medical Allowance"
+msgstr "Bono de medicina"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract__medical_allowance
+msgid "Medical allowance"
+msgstr "Medical Allowance"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_has_error
+#, fuzzy
+msgid "Message Delivery error"
+msgstr "Error de entrega de mensajes"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_ids
+#, fuzzy
+msgid "Messages"
+msgstr "Mensajes"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__condition_range_min
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__condition_range_min
 msgid "Minimum Range"
-msgstr ""
+msgstr "Intervalo mínimo"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Miscelánea"
 
 #. module: om_hr_payroll
-#: selection:hr.contract,schedule_pay:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_contract__schedule_pay__monthly
 msgid "Monthly"
-msgstr ""
+msgstr "Mensual"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_name
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_name
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_contract_form_inherit
+msgid "Monthly Advantages in Cash"
+msgstr "Beneficios mensuales en efectivo"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__my_activity_date_deadline
+#, fuzzy
+msgid "My Activity Deadline"
+msgstr "Fecha límite de mi actividad"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_type__name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__name
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__name
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_payslip.py:197
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract_type__name
+msgid "Name of the contract"
+msgstr "Nombre de contrato"
+
+#. module: om_hr_payroll
+#: model:hr.salary.rule.category,name:om_hr_payroll.NET
+msgid "Net"
+msgstr "Neto"
+
+#. module: om_hr_payroll
+#: model:hr.salary.rule,name:om_hr_payroll.hr_rule_net
+msgid "Net Salary"
+msgstr "Salario neto"
+
+#. module: om_hr_payroll
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_contract_history_view_form
+msgid "New Contract"
+msgstr "Nuevo contrato"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__activity_calendar_event_id
+#, fuzzy
+msgid "Next Activity Calendar Event"
+msgstr "Siguiente evento del calendario de actividades"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__activity_date_deadline
+#, fuzzy
+msgid "Next Activity Deadline"
+msgstr "Fecha límite de la próxima actividad"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__activity_summary
+#, fuzzy
+msgid "Next Activity Summary"
+msgstr "Resumen de la siguiente actividad"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__activity_type_id
+#, fuzzy
+msgid "Next Activity Type"
+msgstr "Siguiente tipo de actividad"
+
+#. module: om_hr_payroll
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
+#, fuzzy, python-format
+msgid ""
+"No running contract found for the employee: %s or no contract in the given "
+"period"
+msgstr ""
+"No se encontró ningún contrato en curso para el empleado: %s o ningún "
+"contrato en el período dado"
+
+#. module: om_hr_payroll
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
 #, python-format
 msgid "Normal Working Days paid at 100%"
-msgstr ""
+msgstr "Días de trabajo normales pagados al 100%"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_category_form
 msgid "Notes"
-msgstr ""
+msgstr "Notas"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_number_of_days
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_needaction_counter
+#, fuzzy
+msgid "Number of Actions"
+msgstr "Número de acciones"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__number_of_days
 msgid "Number of Days"
-msgstr ""
+msgstr "Número de días"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_number_of_hours
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__number_of_hours
 msgid "Number of Hours"
-msgstr ""
+msgstr "Número de horas"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_has_error_counter
+#, fuzzy
+msgid "Number of errors"
+msgstr "Número de errores"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__message_needaction_counter
+#, fuzzy
+msgid "Number of messages which requires an action"
+msgstr "Número de mensajes que requieren una acción"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__message_has_error_counter
+#, fuzzy
+msgid "Number of messages with delivery error"
+msgstr "Número de mensajes con error de entrega"
 
 #. module: om_hr_payroll
 #: model:res.groups,name:om_hr_payroll.group_hr_payroll_user
 msgid "Officer"
-msgstr ""
+msgstr "Oficial"
+
+#. module: om_hr_payroll
+#: model:hr.salary.rule.category,name:om_hr_payroll.Other
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract__other_allowance
+msgid "Other Allowance"
+msgstr "Otras bonificaciones"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Other Inputs"
-msgstr ""
+msgstr "Otras entradas"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_parent_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category_parent_id
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract__other_allowance
+msgid "Other allowances"
+msgstr "Otros bonos"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__parent_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_category__parent_id
 msgid "Parent"
-msgstr ""
+msgstr "Padre"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_parent_rule_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_parent_rule_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__parent_rule_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__parent_rule_id
 msgid "Parent Salary Rule"
-msgstr ""
+msgstr "Regla salarial del padre"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_partner_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__partner_id
 msgid "Partner"
 msgstr "Empresa"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_payslip
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_payslip_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_slip_id
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_payslip_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__payslip_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__slip_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__payslip_id
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "Pay Slip"
-msgstr ""
+msgstr "Nómina"
+
+#. module: om_hr_payroll
+#: model:ir.actions.report,name:om_hr_payroll.action_report_payslip
+#, fuzzy
+msgid "PaySlip"
+msgstr "Nómina"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
 msgid "PaySlip Batch"
-msgstr ""
+msgstr "Procesamiento de nómina"
 
 #. module: om_hr_payroll
 #: model:ir.actions.report,name:om_hr_payroll.payslip_details_report
 msgid "PaySlip Details"
-msgstr ""
+msgstr "Detalles de la nómina"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.action_payslip_lines_contribution_register
 msgid "PaySlip Lines"
-msgstr ""
+msgstr "Líneas de nómina"
 
 #. module: om_hr_payroll
 #: model:ir.actions.report,name:om_hr_payroll.action_contribution_register
-msgid "PaySlip Lines By Conribution Register"
-msgstr ""
+msgid "PaySlip Lines By Contribution Register"
+msgstr "Líneas de nómina por registro de contribución"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
 msgid "PaySlip Lines by Contribution Register"
-msgstr ""
-
-#. module: om_hr_payroll
-#: model:ir.model,name:om_hr_payroll.model_payslip_lines_contribution_register
-msgid "PaySlip Lines by Contribution Registers"
-msgstr ""
+msgstr "Líneas de nómina por registro de contribución"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
 msgid "PaySlip Name"
-msgstr ""
+msgstr "Nombre de la nómina"
 
 #. module: om_hr_payroll
 #: model:ir.ui.menu,name:om_hr_payroll.menu_hr_payroll_root
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.res_config_settings_view_form
 msgid "Payroll"
-msgstr ""
+msgstr "Nómina"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_res_config_settings__module_om_hr_payroll_account
+#, fuzzy
+msgid "Payroll Accounting"
+msgstr "Contabilidad de nómina"
+
+#. module: om_hr_payroll
+#: model:ir.model,name:om_hr_payroll.model_report_om_om_hr_payroll_report_contribution_register
+#, fuzzy
+msgid "Payroll Contribution Register Report"
+msgstr "Informe de registro de contribuciones de nómina"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.res_config_settings_view_form
 msgid "Payroll Entries"
-msgstr ""
-
-#. module: om_hr_payroll
-#: model_terms:ir.ui.view,arch_db:om_hr_payroll.res_config_settings_view_form
-msgid "Payroll Rules"
-msgstr ""
+msgstr "Registros de la nómina"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payroll_structure_filter
 msgid "Payroll Structures"
-msgstr ""
+msgstr "Estructuras de sueldos"
 
 #. module: om_hr_payroll
-#: model_terms:ir.ui.view,arch_db:om_hr_payroll.res_config_settings_view_form
-msgid "Payroll rules that apply to your country"
-msgstr ""
-
-#. module: om_hr_payroll
-#: model:ir.actions.report,name:om_hr_payroll.action_report_payslip
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.payroll_hr_employee_view_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Payslip"
-msgstr ""
+msgstr "Nómina"
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_payslip.py:84
-#, python-format
-msgid "Payslip 'Date From' must be before 'Date To'."
-msgstr ""
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
+#, fuzzy, python-format
+msgid "Payslip 'Date From' must be earlier 'Date To'."
+msgstr "La nómina 'Fecha desde' debe ser anterior 'Fecha hasta'."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_payslip_run_id
+#: model:ir.model,name:om_hr_payroll.model_hr_payslip_run
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__payslip_run_id
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_filter
 msgid "Payslip Batches"
-msgstr ""
+msgstr "Procesamientos de nóminas"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.act_payslip_lines
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_payslip_count
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__payslip_count
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Payslip Computation Details"
-msgstr ""
+msgstr "Detalles de cálculo de nómina"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_employee__payslip_count
+msgid "Payslip Count"
+msgstr "Cantidad de nóminas"
+
+#. module: om_hr_payroll
+#: model:ir.model,name:om_hr_payroll.model_report_om_hr_payroll_report_payslip_details
+#, fuzzy
+msgid "Payslip Details Report"
+msgstr "Informe de detalles de nómina"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_payslip_input
 msgid "Payslip Input"
-msgstr ""
+msgstr "Entrada de nómina"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_line_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__input_line_ids
 msgid "Payslip Inputs"
-msgstr ""
+msgstr "Entradas de nómina"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_payslip_line
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_line_form
 msgid "Payslip Line"
-msgstr ""
+msgstr "Línea de nómina"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.act_contribution_reg_payslip_lines
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__line_ids
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_line_filter
 msgid "Payslip Lines"
-msgstr ""
+msgstr "Líneas de nómina"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "Payslip Lines by Contribution Register"
-msgstr ""
+msgstr "Líneas de nómina por registro de contribución"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_name
+#: model:ir.model,name:om_hr_payroll.model_payslip_lines_contribution_register
+#, fuzzy
+msgid "Payslip Lines by Contribution Registers"
+msgstr "Líneas de nómina por registros de cotización"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__name
 msgid "Payslip Name"
-msgstr ""
+msgstr "Nombre de nómina"
 
 #. module: om_hr_payroll
-#: model:ir.model,name:om_hr_payroll.model_hr_payslip_run
-msgid "Payslip Run"
-msgstr ""
+#: model:mail.template,name:om_hr_payroll.mail_template_payslip
+#, fuzzy
+msgid "Payslip Template"
+msgstr "Plantilla de nómina"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_payslip_worked_days
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_line_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__worked_days_line_ids
 msgid "Payslip Worked Days"
-msgstr ""
+msgstr "Días trabajados de la nómina"
+
+#. module: om_hr_payroll
+#: model:mail.template,subject:om_hr_payroll.mail_template_payslip
+#, fuzzy
+msgid "Payslip: {{ object.number }}"
+msgstr "Nómina: {{ object.number }}"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.act_hr_employee_payslip_list
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_employee_payslip_count
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_employee_slip_ids
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_slip_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_employee__slip_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__slip_ids
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_form
-#: model_terms:ir.ui.view,arch_db:om_hr_payroll.payroll_hr_employee_view_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_tree
 msgid "Payslips"
-msgstr ""
+msgstr "Nóminas"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.action_hr_payslip_run_tree
@@ -1050,37 +1574,37 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_tree
 msgid "Payslips Batches"
-msgstr ""
+msgstr "Procesamientos de nóminas"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_by_employees
 msgid "Payslips by Employees"
-msgstr ""
+msgstr "Nóminas por empleados"
 
 #. module: om_hr_payroll
-#: selection:hr.payslip.line,amount_select:0
-#: selection:hr.salary.rule,amount_select:0
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_amount_percentage
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_amount_percentage
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__amount_percentage
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__amount_percentage
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip_line__amount_select__percentage
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_salary_rule__amount_select__percentage
 msgid "Percentage (%)"
-msgstr ""
+msgstr "Porcentaje (%)"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_amount_percentage_base
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_amount_percentage_base
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__amount_percentage_base
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__amount_percentage_base
 msgid "Percentage based on"
-msgstr ""
+msgstr "Porcentaje basado en"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Period"
-msgstr ""
+msgstr "Período"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.res_config_settings_view_form
 msgid "Post payroll slips in accounting"
-msgstr ""
+msgstr "Publicar recibos de nómina en contabilidad"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_payslip_lines_contribution_register
@@ -1088,137 +1612,160 @@ msgid "Print"
 msgstr "Imprimir"
 
 #. module: om_hr_payroll
-#: selection:hr.payslip.line,amount_select:0
-#: selection:hr.salary.rule,amount_select:0
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_amount_python_compute
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_amount_python_compute
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__amount_python_compute
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__amount_python_compute
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip_line__amount_select__code
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_salary_rule__amount_select__code
 msgid "Python Code"
-msgstr ""
+msgstr "Código Python"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_condition_python
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_condition_python
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__condition_python
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__condition_python
 msgid "Python Condition"
-msgstr ""
+msgstr "Condición python"
 
 #. module: om_hr_payroll
-#: selection:hr.payslip.line,condition_select:0
-#: selection:hr.salary.rule,condition_select:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip_line__condition_select__python
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_salary_rule__condition_select__python
 msgid "Python Expression"
-msgstr ""
+msgstr "Expresión python"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_quantity
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_quantity
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__quantity
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__quantity
 msgid "Quantity"
 msgstr "Cantidad"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
 msgid "Quantity/Rate"
-msgstr ""
+msgstr "Cantidad/Calificación"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 msgid "Quantity/rate"
-msgstr ""
+msgstr "Cantidad/Tasa"
 
 #. module: om_hr_payroll
-#: selection:hr.contract,schedule_pay:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_contract__schedule_pay__quarterly
 msgid "Quarterly"
-msgstr ""
+msgstr "Trimestralmente"
 
 #. module: om_hr_payroll
-#: selection:hr.payslip.line,condition_select:0
-#: selection:hr.salary.rule,condition_select:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip_line__condition_select__range
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_salary_rule__condition_select__range
 msgid "Range"
-msgstr ""
+msgstr "Intervalo"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_condition_range
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_condition_range
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__condition_range
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__condition_range
 msgid "Range Based on"
-msgstr ""
+msgstr "Intervalo basado en"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_rate
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__rate
 msgid "Rate (%)"
-msgstr ""
+msgstr "Tasa (%)"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_code
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_number
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__code
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__number
 msgid "Reference"
-msgstr ""
+msgstr "Referencia"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Refund"
-msgstr ""
+msgstr "Factura rectificativa"
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_payslip.py:104
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
+#, fuzzy, python-format
+msgid "Refund Payslip"
+msgstr "Reembolso de nómina"
+
+#. module: om_hr_payroll
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
 #, python-format
 msgid "Refund: "
-msgstr ""
+msgstr "Devolución: "
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register_register_line_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contribution_register__register_line_ids
 msgid "Register Line"
-msgstr ""
+msgstr "Línea registro"
 
 #. module: om_hr_payroll
-#: selection:hr.payslip,state:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip__state__cancel
 msgid "Rejected"
-msgstr ""
+msgstr "Rechazada"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_salary_rule_id
+#: model:ir.model,name:om_hr_payroll.model_resource_mixin
+msgid "Resource Mixin"
+msgstr "Mixin de recursos"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__activity_user_id
+#, fuzzy
+msgid "Responsible User"
+msgstr "Usuario responsable"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__salary_rule_id
 msgid "Rule"
-msgstr ""
+msgstr "Regla"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__message_has_sms_error
+#, fuzzy
+msgid "SMS Delivery error"
+msgstr "Error de entrega de SMS"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_category_form
 msgid "Salary Categories"
-msgstr ""
+msgstr "Categorías salariales"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Salary Computation"
-msgstr ""
+msgstr "Cálculo de la nómina"
+
+#. module: om_hr_payroll
+#: model:ir.model,name:om_hr_payroll.model_hr_salary_rule
+msgid "Salary Rule"
+msgstr "Regla salarial"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.action_hr_salary_rule_category
 #: model:ir.ui.menu,name:om_hr_payroll.menu_hr_salary_rule_category
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_category_tree
-#: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_category_tree_view
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_salary_rule_category_filter
 msgid "Salary Rule Categories"
-msgstr ""
-
-#. module: om_hr_payroll
-#: model:ir.actions.act_window,name:om_hr_payroll.action_hr_salary_rule_category_tree_view
-#: model:ir.ui.menu,name:om_hr_payroll.menu_hr_salary_rule_category_tree_view
-msgid "Salary Rule Categories Hierarchy"
-msgstr ""
+msgstr "Categorías de reglas salariales"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_salary_rule_category
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_line_filter
 msgid "Salary Rule Category"
-msgstr ""
+msgstr "Categoría de regla salarial"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_rule_input
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input_input_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_rule_input__input_id
 msgid "Salary Rule Input"
-msgstr ""
+msgstr "Entrada de regla salarial"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.action_salary_rule_form
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure_rule_ids
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payroll_structure__rule_ids
 #: model:ir.ui.menu,name:om_hr_payroll.menu_action_hr_salary_rule_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_salary_rule_list
@@ -1226,65 +1773,78 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_employee_grade_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_rule_filter
 msgid "Salary Rules"
-msgstr ""
+msgstr "Reglas salariales"
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_payslip.py:396
-#: code:addons/om_hr_payroll/models/hr_payslip.py:446
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
 #, python-format
 msgid "Salary Slip of %s for %s"
-msgstr ""
+msgstr "Nómina salarial de %s para %s"
 
 #. module: om_hr_payroll
 #: model:ir.model,name:om_hr_payroll.model_hr_payroll_structure
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_struct_id
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract__struct_id
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payroll_structure_tree
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_line_tree
 msgid "Salary Structure"
-msgstr ""
+msgstr "Estructura salarial"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.action_view_hr_payroll_structure_list_form
 #: model:ir.ui.menu,name:om_hr_payroll.menu_hr_payroll_structure_view
 msgid "Salary Structures"
-msgstr ""
+msgstr "Estructuras salariales"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_schedule_pay
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract__schedule_pay
 msgid "Scheduled Pay"
-msgstr ""
+msgstr "Pago planificado"
+
+#. module: om_hr_payroll
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_contract_type_search
+msgid "Search Contract Type"
+msgstr "Buscar tipo de contrato"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_filter
 msgid "Search Payslip Batches"
-msgstr ""
+msgstr "Buscar procesamientos de nóminas"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_line_filter
 msgid "Search Payslip Lines"
-msgstr ""
+msgstr "Buscar líneas de nómina"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
 msgid "Search Payslips"
-msgstr ""
+msgstr "Buscar nóminas"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_rule_filter
 msgid "Search Salary Rule"
-msgstr ""
+msgstr "Buscar regla salarial"
 
 #. module: om_hr_payroll
-#: selection:hr.contract,schedule_pay:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_contract__schedule_pay__semi-annually
 msgid "Semi-annually"
-msgstr ""
+msgstr "Semestral"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input_sequence
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_sequence
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days_sequence
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule_sequence
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
+#, fuzzy
+msgid "Send E-Mail"
+msgstr "Enviar correo electrónico"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_type__sequence
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_input__sequence
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__sequence
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_worked_days__sequence
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_salary_rule__sequence
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_contract_type_search
 msgid "Sequence"
 msgstr "Secuencia"
 
@@ -1292,215 +1852,265 @@ msgstr "Secuencia"
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.hr_payslip_run_form
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Set to Draft"
-msgstr ""
+msgstr "Cambiar a borrador"
 
 #. module: om_hr_payroll
 #: model:ir.actions.act_window,name:om_hr_payroll.action_hr_payroll_configuration
 #: model:ir.ui.menu,name:om_hr_payroll.menu_hr_payroll_global_settings
 msgid "Settings"
-msgstr ""
+msgstr "Configuración"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_filter
 msgid "States"
-msgstr ""
+msgstr "Estados"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run_state
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_state
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__state
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_run__state
 msgid "Status"
 msgstr "Estado"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_struct_id
-msgid "Structure"
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__activity_state
+#, fuzzy
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
 msgstr ""
+"Estado basado en actividades\n"
+"Atrasado: la fecha de vencimiento ya pasó\n"
+"Hoy: la fecha de la actividad es hoy\n"
+"Planificado: Actividades futuras."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_code
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_code
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__struct_id
+msgid "Structure"
+msgstr "Estructura"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__code
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__code
 msgid ""
 "The code of salary rules can be used as reference in computation of other "
 "rules. In that case, it is case sensitive."
 msgstr ""
+"El código de las reglas salariales puede ser usado como referencia en el "
+"cálculo de otras reglas. En ese caso, se distingue entre mayúsculas y "
+"minúsculas."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_input_code
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_worked_days_code
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_rule_input_code
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_input__code
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_worked_days__code
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_rule_input__code
 msgid "The code that can be used in the salary rules"
-msgstr ""
+msgstr "El código puede ser usado en las reglas salariales"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_amount_select
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_amount_select
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__amount_select
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__amount_select
 msgid "The computation method for the rule amount."
-msgstr ""
+msgstr "El método de cálculo para el importe de la regla."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_input_contract_id
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_worked_days_contract_id
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_input__contract_id
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_worked_days__contract_id
 msgid "The contract for which applied this input"
-msgstr ""
+msgstr "El contrato para el que aplica esta entrada"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_condition_range_max
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_condition_range_max
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__condition_range_max
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__condition_range_max
 msgid "The maximum amount, applied for this rule."
-msgstr ""
+msgstr "El importe máximo aplicado a esta regla."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_condition_range_min
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_condition_range_min
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__condition_range_min
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__condition_range_min
 msgid "The minimum amount, applied for this rule."
-msgstr ""
+msgstr "El importe mínimo aplicado a esta regla."
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_condition_range
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_condition_range
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__condition_range
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__condition_range
 msgid ""
-"This will be used to compute the % fields values; in general it is on basic,"
-" but you can also use categories code fields in lowercase as a variable "
-"names (hra, ma, lta, etc.) and the variable basic."
+"This will be used to compute the % fields values; in general it is on "
+"basic, but you can also use categories code fields in lowercase as a "
+"variable names (hra, ma, lta, etc.) and the variable basic."
 msgstr ""
+"Se usará para calcular el valor de los campos %; en general se utiliza lo "
+"básico, pero también puede usar campos de código de categorías en minúscula "
+"como nombres de variables (hra, ma, lta, etc.) y las variables básicas."
 
 #. module: om_hr_payroll
-#: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_by_employees
-msgid ""
-"This wizard will generate payslips for all selected employee(s) based on the"
-" dates and credit note specified on Payslips Run."
-msgstr ""
+#: model:ir.model,name:om_hr_payroll.model_hr_leave_type
+msgid "Time Off Type"
+msgstr "Tipo de ausencia"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line_total
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip_line__total
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_contribution_register
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.report_payslip_details
+#, fuzzy
 msgid "Total"
 msgstr "Total"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Total Working Days"
-msgstr ""
+msgstr "Días de trabajo totales"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template_upper_bound
+#: model:hr.salary.rule,name:om_hr_payroll.hr_rule_travel
+#: model:hr.salary.rule.category,name:om_hr_payroll.Travel
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract__travel_allowance
+msgid "Travel Allowance"
+msgstr "Bono de viaje"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract__travel_allowance
+#, fuzzy
+msgid "Travel allowance"
+msgstr "Dietas de viaje"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__activity_exception_decoration
+#, fuzzy
+msgid "Type of the exception activity on record."
+msgstr "Tipo de actividad de excepción registrada."
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract_advantage_template__upper_bound
 msgid "Upper Bound"
-msgstr ""
+msgstr "Límite superior"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract_advantage_template_upper_bound
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_contract_advantage_template__upper_bound
 msgid "Upper bound authorized by the employer for this advantage"
-msgstr ""
+msgstr "Límite superior autorizado por el empleador para esta ventaja"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_sequence
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_sequence
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__sequence
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__sequence
 msgid "Use to arrange calculation sequence"
-msgstr ""
+msgstr "Se utiliza para organizar la secuencia de cálculo"
 
 #. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_appears_on_payslip
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_appears_on_payslip
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__appears_on_payslip
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__appears_on_payslip
 msgid "Used to display the salary rule on payslip."
-msgstr ""
+msgstr "Se usa para mostrar la regla de salario en la nómina."
 
 #. module: om_hr_payroll
-#: selection:hr.payslip,state:0
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_payslip__state__verify
 msgid "Waiting"
-msgstr ""
+msgstr "En espera"
 
 #. module: om_hr_payroll
-#: selection:hr.contract,schedule_pay:0
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_payslip__website_message_ids
+#, fuzzy
+msgid "Website Messages"
+msgstr "Mensajes del sitio web"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__website_message_ids
+#, fuzzy
+msgid "Website communication history"
+msgstr "Historial de comunicación del sitio web"
+
+#. module: om_hr_payroll
+#: model:ir.model.fields.selection,name:om_hr_payroll.selection__hr_contract__schedule_pay__weekly
 msgid "Weekly"
-msgstr ""
+msgstr "Semanalmente"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Worked Day"
-msgstr ""
+msgstr "Días trabajados"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Worked Days"
-msgstr ""
+msgstr "Días trabajados"
 
 #. module: om_hr_payroll
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll.view_hr_payslip_form
 msgid "Worked Days & Inputs"
-msgstr ""
+msgstr "Días trabajados y entradas"
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_salary_rule.py:198
+#: model:ir.model.fields,field_description:om_hr_payroll.field_hr_contract__resource_calendar_id
+msgid "Working Schedule"
+msgstr "Programa de trabajo"
+
+#. module: om_hr_payroll
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_salary_rule.py:0
 #, python-format
 msgid "Wrong percentage base or quantity defined for salary rule %s (%s)."
-msgstr ""
+msgstr "Porcentaje base o cantidad errónea para la regla de salario %s (%s)."
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_salary_rule.py:204
-#, python-format
-msgid "Wrong python code defined for salary rule %s (%s)."
-msgstr ""
-
-#. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_salary_rule.py:227
-#, python-format
-msgid "Wrong python condition defined for salary rule %s (%s)."
-msgstr ""
-
-#. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_salary_rule.py:191
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_salary_rule.py:0
 #, python-format
 msgid "Wrong quantity defined for salary rule %s (%s)."
-msgstr ""
+msgstr "Cantidad errónea definida para la regla de salario %s (%s)."
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_salary_rule.py:221
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_salary_rule.py:0
 #, python-format
 msgid "Wrong range condition defined for salary rule %s (%s)."
-msgstr ""
+msgstr "Rango de condición erróneo para la regla de salario %s (%s)."
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_payslip.py:128
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
+#, python-format
+msgid "You Cannot Delete Done Payslips Batches"
+msgstr "No puede eliminar lotes de recibos de pago terminados"
+
+#. module: om_hr_payroll
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_salary_rule.py:0
+#, python-format
+msgid "You cannot create a recursive salary structure."
+msgstr "No se pueden crear estructuras salariales recursivas."
+
+#. module: om_hr_payroll
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
 #, python-format
 msgid "You cannot delete a payslip which is not draft or cancelled!"
 msgstr ""
+"¡No puede eliminar una nómina que no esté en estado borrador o cancenlado!"
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/wizard/hr_payroll_payslips_by_employees.py:24
+#. odoo-python
+#: code:addons/om_hr_payroll/wizard/hr_payroll_payslips_by_employees.py:0
 #, python-format
 msgid "You must select employee(s) to generate payslip(s)."
-msgstr ""
+msgstr "Debe seleccionar un empleado(s) para crear la(s) nómina(s)."
 
 #. module: om_hr_payroll
-#: code:addons/om_hr_payroll/models/hr_payslip.py:517
+#. odoo-python
+#: code:addons/om_hr_payroll/models/hr_payslip.py:0
 #, python-format
 msgid "You must set a contract to create a payslip line."
-msgstr ""
+msgstr "Debe crear un contrato para crear una línea de colilla de pago."
 
 #. module: om_hr_payroll
-#: model:ir.model,name:om_hr_payroll.model_hr_salary_rule
-msgid "hr.salary.rule"
-msgstr ""
-
-#. module: om_hr_payroll
-#: model:ir.model,name:om_hr_payroll.model_report_hr_payroll_report_contribution_register
-msgid "report.om_hr_payroll.report_contribution_register"
-msgstr ""
-
-#. module: om_hr_payroll
-#: model:ir.model,name:om_hr_payroll.model_report_hr_payroll_report_payslip_details
-msgid "report.om_hr_payroll.report_payslip_details"
-msgstr ""
-
-#. module: om_hr_payroll
-#: model:ir.model,name:om_hr_payroll.model_res_config_settings
-msgid "res.config.settings"
-msgstr ""
-
-#. module: om_hr_payroll
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line_amount_percentage_base
-#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule_amount_percentage_base
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip_line__amount_percentage_base
+#: model:ir.model.fields,help:om_hr_payroll.field_hr_salary_rule__amount_percentage_base
 msgid "result will be affected to a variable"
-msgstr ""
+msgstr "el resultado afectará a una variable"
+
+#. module: om_hr_payroll
+#: model:mail.template,report_name:om_hr_payroll.mail_template_payslip
+#, fuzzy
+msgid "{{ (object.number or '').replace('/','_') }}"
+msgstr "{{ (object.number or '').replace('/','_') }}"

--- a/om_hr_payroll_account/i18n/es_CR.po
+++ b/om_hr_payroll_account/i18n/es_CR.po
@@ -1,127 +1,161 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * hr_payroll_account
-# 
-# Translators:
-# Martin Trigaux <mat@odoo.com>, 2017
+# 	* om_hr_payroll_account
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.saas~18\n"
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-20 09:53+0000\n"
-"PO-Revision-Date: 2017-09-20 09:53+0000\n"
-"Last-Translator: Martin Trigaux <mat@odoo.com>, 2017\n"
-"Language-Team: Spanish (Costa Rica) (https://www.transifex.com/odoo/teams/41243/es_CR/)\n"
+"POT-Creation-Date: 2023-07-08 21:06+0000\n"
+"PO-Revision-Date: 2023-07-08 15:07-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Language: es_CR\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
 
-#. module: hr_payroll_account
+#. module: om_hr_payroll_account
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll_account.hr_contract_form_inherit
 #: model_terms:ir.ui.view,arch_db:om_hr_payroll_account.hr_salary_rule_form_inherit
 msgid "Accounting"
-msgstr ""
+msgstr "Contabilidad"
 
-#. module: hr_payroll_account
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_move_id
+#. module: om_hr_payroll_account
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip__move_id
 msgid "Accounting Entry"
-msgstr ""
+msgstr "Asiento contable"
 
-#. module: hr_payroll_account
-#: code:addons/hr_payroll_account/models/om_hr_payroll_account.py:113
-#: code:addons/hr_payroll_account/models/om_hr_payroll_account.py:128
+#. module: om_hr_payroll_account
+#. odoo-python
+#: code:addons/om_hr_payroll_account/models/hr_payroll_account.py:0
 #, python-format
 msgid "Adjustment Entry"
-msgstr ""
+msgstr "Asiento de ajuste"
 
-#. module: hr_payroll_account
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_contract_analytic_account_id
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_line_analytic_account_id
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_salary_rule_analytic_account_id
-msgid "Analytic Account"
-msgstr "Cuenta analítica"
+#. module: om_hr_payroll_account
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_contract__analytic_distribution
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_salary_rule__analytic_distribution
+#, fuzzy
+msgid "Analytic"
+msgstr "Analítico"
 
-#. module: hr_payroll_account
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_line_account_credit
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_salary_rule_account_credit
+#. module: om_hr_payroll_account
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_contract__analytic_distribution_search
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_salary_rule__analytic_distribution_search
+#, fuzzy
+msgid "Analytic Distribution Search"
+msgstr "Búsqueda de distribución analítica"
+
+#. module: om_hr_payroll_account
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_contract__analytic_precision
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_salary_rule__analytic_precision
+#, fuzzy
+msgid "Analytic Precision"
+msgstr "Precisión analítica"
+
+#. module: om_hr_payroll_account
+#: model_terms:ir.ui.view,arch_db:om_hr_payroll_account.view_hr_payslip_inherit_form
+#, fuzzy
+msgid "Are you sure to delete the related accounting entry ?"
+msgstr "¿Está seguro de eliminar la entrada contable relacionada?"
+
+#. module: om_hr_payroll_account
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_line__account_credit
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_salary_rule__account_credit
 msgid "Credit Account"
-msgstr ""
+msgstr "Cuenta acreedora"
 
-#. module: hr_payroll_account
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_date
+#. module: om_hr_payroll_account
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip__date
 msgid "Date Account"
-msgstr ""
+msgstr "Fecha de la Cuenta"
 
-#. module: hr_payroll_account
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_line_account_debit
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_salary_rule_account_debit
+#. module: om_hr_payroll_account
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_line__account_debit
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_salary_rule__account_debit
 msgid "Debit Account"
-msgstr ""
+msgstr "Cuenta deudora"
 
-#. module: hr_payroll_account
+#. module: om_hr_payroll_account
 #: model:ir.model,name:om_hr_payroll_account.model_hr_contract
 msgid "Employee Contract"
-msgstr ""
+msgstr "Contrato de empleado"
 
-#. module: hr_payroll_account
+#. module: om_hr_payroll_account
 #: model:ir.model,name:om_hr_payroll_account.model_hr_payslip_employees
 msgid "Generate payslips for all selected employees"
-msgstr ""
+msgstr "Generar las nóminas para todos los empleados seleccionados"
 
-#. module: hr_payroll_account
-#: model:ir.model.fields,help:om_hr_payroll_account.field_hr_payslip_date
+#. module: om_hr_payroll_account
+#: model:ir.model.fields,help:om_hr_payroll_account.field_hr_payslip__date
 msgid "Keep empty to use the period of the validation(Payslip) date."
 msgstr ""
+"Deje en blanco para usar el período de la fecha de validación de la nómina."
 
-#. module: hr_payroll_account
+#. module: om_hr_payroll_account
+#. odoo-python
+#: code:addons/om_hr_payroll_account/models/hr_payroll_account.py:0
+#, fuzzy, python-format
+msgid "Missing Debit Or Credit Account in Salary Rule"
+msgstr "Falta una cuenta de débito o crédito en la regla salarial"
+
+#. module: om_hr_payroll_account
 #: model:ir.model,name:om_hr_payroll_account.model_hr_payslip
 msgid "Pay Slip"
-msgstr ""
+msgstr "Nómina"
 
-#. module: hr_payroll_account
+#. module: om_hr_payroll_account
+#: model:ir.model,name:om_hr_payroll_account.model_hr_payslip_run
+msgid "Payslip Batches"
+msgstr "Procesamientos de nóminas"
+
+#. module: om_hr_payroll_account
 #: model:ir.model,name:om_hr_payroll_account.model_hr_payslip_line
 msgid "Payslip Line"
-msgstr ""
+msgstr "Línea de nómina"
 
-#. module: hr_payroll_account
-#: model:ir.model,name:om_hr_payroll_account.model_hr_payslip_run
-msgid "Payslip Run"
-msgstr ""
-
-#. module: hr_payroll_account
-#: code:addons/hr_payroll_account/models/om_hr_payroll_account.py:64
+#. module: om_hr_payroll_account
+#. odoo-python
+#: code:addons/om_hr_payroll_account/models/hr_payroll_account.py:0
 #, python-format
 msgid "Payslip of %s"
-msgstr ""
+msgstr "Nómina de %s"
 
-#. module: hr_payroll_account
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_contract_journal_id
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_journal_id
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_run_journal_id
+#. module: om_hr_payroll_account
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_contract__journal_id
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip__journal_id
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_run__journal_id
 msgid "Salary Journal"
-msgstr ""
+msgstr "Diario de salarios"
 
-#. module: hr_payroll_account
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_line_account_tax_id
-#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_salary_rule_account_tax_id
+#. module: om_hr_payroll_account
+#: model:ir.model,name:om_hr_payroll_account.model_hr_salary_rule
+msgid "Salary Rule"
+msgstr "Regla salarial"
+
+#. module: om_hr_payroll_account
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_payslip_line__account_tax_id
+#: model:ir.model.fields,field_description:om_hr_payroll_account.field_hr_salary_rule__account_tax_id
 msgid "Tax"
-msgstr ""
+msgstr "Impuesto"
 
-#. module: hr_payroll_account
-#: code:addons/hr_payroll_account/models/om_hr_payroll_account.py:111
+#. module: om_hr_payroll_account
+#. odoo-python
+#: code:addons/om_hr_payroll_account/models/hr_payroll_account.py:0
 #, python-format
 msgid "The Expense Journal \"%s\" has not properly configured the Credit Account!"
 msgstr ""
+"¡La cuenta acreedora del diario de gastos \"%s\" no se ha configurado "
+"correctamente!"
 
-#. module: hr_payroll_account
-#: code:addons/hr_payroll_account/models/om_hr_payroll_account.py:126
+#. module: om_hr_payroll_account
+#. odoo-python
+#: code:addons/om_hr_payroll_account/models/hr_payroll_account.py:0
 #, python-format
 msgid "The Expense Journal \"%s\" has not properly configured the Debit Account!"
 msgstr ""
-
-#. module: hr_payroll_account
-#: model:ir.model,name:om_hr_payroll_account.model_hr_salary_rule
-msgid "hr.salary.rule"
-msgstr ""
+"¡La cuenta deudora del diario de gastos \"%s\" no se ha configurado "
+"correctamente!"

--- a/om_mass_confirm_cancel/i18n/es_CR.po
+++ b/om_mass_confirm_cancel/i18n/es_CR.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_mass_confirm_cancel
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 21:08+0000\n"
+"PO-Revision-Date: 2023-07-08 15:08-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_mass_confirm_cancel
+#: model:ir.actions.server,name:om_mass_confirm_cancel.action_purchase_cancel
+#, fuzzy
+msgid "Cancel RFQ"
+msgstr "Cancelar RFQ"
+
+#. module: om_mass_confirm_cancel
+#: model:ir.actions.server,name:om_mass_confirm_cancel.action_sale_cancel
+#, fuzzy
+msgid "Cancel Sale/Quotation"
+msgstr "Cancelar Venta/Cotización"
+
+#. module: om_mass_confirm_cancel
+#: model:ir.actions.server,name:om_mass_confirm_cancel.action_sale_confirm
+#, fuzzy
+msgid "Confirm Quotation"
+msgstr "Confirmar presupuesto"
+
+#. module: om_mass_confirm_cancel
+#: model:ir.actions.server,name:om_mass_confirm_cancel.action_purchase_confirm
+#, fuzzy
+msgid "Confirm RFQ"
+msgstr "Confirmar RFQ"

--- a/om_recurring_payments/i18n/es_CR.po
+++ b/om_recurring_payments/i18n/es_CR.po
@@ -1,0 +1,362 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* om_recurring_payments
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 21:09+0000\n"
+"PO-Revision-Date: 2023-07-08 15:10-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__amount
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__amount
+#, fuzzy
+msgid "Amount"
+msgstr "Importe"
+
+#. module: om_recurring_payments
+#. odoo-python
+#: code:addons/om_recurring_payments/models/recurring_payment.py:0
+#, fuzzy, python-format
+msgid "Amount Must Be Non-Zero Positive Number"
+msgstr "La cantidad debe ser un número positivo distinto de cero"
+
+#. module: om_recurring_payments
+#. odoo-python
+#: code:addons/om_recurring_payments/models/recurring_payment.py:0
+#, fuzzy, python-format
+msgid "Cannot delete done records !"
+msgstr "¡No se pueden eliminar los registros realizados!"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__company_id
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__company_id
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__company_id
+#, fuzzy
+msgid "Company"
+msgstr "Compañía"
+
+#. module: om_recurring_payments
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_template_form
+#, fuzzy
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: om_recurring_payments
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_payment_form
+#, fuzzy
+msgid "Create Payment"
+msgstr "Crear Pago"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__create_uid
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__create_uid
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__create_uid
+#, fuzzy
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__create_date
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__create_date
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__create_date
+#, fuzzy
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__currency_id
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__currency_id
+#, fuzzy
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__date
+#, fuzzy
+msgid "Date"
+msgstr "Fecha"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__account_recurring_template__recurring_period__days
+#, fuzzy
+msgid "Days"
+msgstr "Días"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__description
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__description
+#, fuzzy
+msgid "Description"
+msgstr "Descripción"
+
+#. module: om_recurring_payments
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_payment_form
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_template_form
+#, fuzzy
+msgid "Description..."
+msgstr "Descripción"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__display_name
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__display_name
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__display_name
+#, fuzzy
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__account_recurring_template__state__done
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__recurring_payment__state__done
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__recurring_payment_line__state__done
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_payment_form
+#, fuzzy
+msgid "Done"
+msgstr "Realizado"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__account_recurring_template__state__draft
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__recurring_payment__state__draft
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__recurring_payment_line__state__draft
+#, fuzzy
+msgid "Draft"
+msgstr "Borrador"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__date_end
+#, fuzzy
+msgid "End Date"
+msgstr "Fecha final"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__journal_state
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__journal_state
+#, fuzzy
+msgid "Generate Journal As"
+msgstr "Generar asiento contable"
+
+#. module: om_recurring_payments
+#: model:ir.actions.server,name:om_recurring_payments.action_generate_recurring_payment_ir_actions_server
+#: model:ir.cron,cron_name:om_recurring_payments.action_generate_recurring_payment
+#, fuzzy
+msgid "Generate Recurring Payments"
+msgstr "Generar pagos recurrentes"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__id
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__id
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__id
+#, fuzzy
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__journal_id
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__journal_id
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__journal_id
+#, fuzzy
+msgid "Journal"
+msgstr "Diario"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template____last_update
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment____last_update
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line____last_update
+#, fuzzy
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__write_uid
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__write_uid
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__write_uid
+#, fuzzy
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__write_date
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__write_date
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__write_date
+#, fuzzy
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__account_recurring_template__recurring_period__months
+#, fuzzy
+msgid "Months"
+msgstr "Meses"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__name
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__name
+#, fuzzy
+msgid "Name"
+msgstr "Nombre"
+
+#. module: om_recurring_payments
+#. odoo-python
+#: code:addons/om_recurring_payments/models/recurring_payment.py:0
+#, fuzzy, python-format
+msgid "New"
+msgstr "Nuevo"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__partner_id
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__partner_id
+#, fuzzy
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__payment_id
+#, fuzzy
+msgid "Payment"
+msgstr "Pago"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__payment_type
+#, fuzzy
+msgid "Payment Type"
+msgstr "Tipo de pago"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__account_recurring_template__journal_state__posted
+#, fuzzy
+msgid "Posted"
+msgstr "Publicado"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__recurring_payment__payment_type__inbound
+#, fuzzy
+msgid "Receive Money"
+msgstr "Recibir dinero"
+
+#. module: om_recurring_payments
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_payment_form
+#, fuzzy
+msgid "Recurring Entries"
+msgstr "Entradas recurrentes"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__recurring_interval
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__recurring_interval
+#, fuzzy
+msgid "Recurring Interval"
+msgstr "Intervalo recurrente"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__line_ids
+#, fuzzy
+msgid "Recurring Lines"
+msgstr "Líneas recurrentes"
+
+#. module: om_recurring_payments
+#: model:ir.actions.act_window,name:om_recurring_payments.action_account_recurring_payment
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__recurring_payment_id
+#: model:ir.ui.menu,name:om_recurring_payments.menu_recurring_payment
+#: model:ir.ui.menu,name:om_recurring_payments.menu_recurring_payments
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_payment_form
+#, fuzzy
+msgid "Recurring Payment"
+msgstr "Pago recurrente"
+
+#. module: om_recurring_payments
+#: model:ir.model,name:om_recurring_payments.model_recurring_payment_line
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_payment_form
+#, fuzzy
+msgid "Recurring Payment Line"
+msgstr "Línea de pago recurrente"
+
+#. module: om_recurring_payments
+#: model:ir.model,name:om_recurring_payments.model_recurring_payment
+#, fuzzy
+msgid "Recurring Payment("
+msgstr "Pago recurrente("
+
+#. module: om_recurring_payments
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_account_recurring_payment_tree
+#, fuzzy
+msgid "Recurring Payments"
+msgstr "Pagos recurrentes"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__recurring_period
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__recurring_period
+#, fuzzy
+msgid "Recurring Period"
+msgstr "Período recurrente"
+
+#. module: om_recurring_payments
+#: model:ir.actions.act_window,name:om_recurring_payments.action_account_recurring_template
+#: model:ir.model,name:om_recurring_payments.model_account_recurring_template
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__template_id
+#: model:ir.ui.menu,name:om_recurring_payments.menu_recurring_template
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_account_recurring_template_tree
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_template_form
+#, fuzzy
+msgid "Recurring Template"
+msgstr "Plantilla recurrente"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__recurring_payment__payment_type__outbound
+#, fuzzy
+msgid "Send Money"
+msgstr "Enviar dinero"
+
+#. module: om_recurring_payments
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_payment_form
+#: model_terms:ir.ui.view,arch_db:om_recurring_payments.view_recurring_template_form
+#, fuzzy
+msgid "Set To Draft"
+msgstr "Restablecer a borrador"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__date_begin
+#, fuzzy
+msgid "Start Date"
+msgstr "Fecha inicial"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields,field_description:om_recurring_payments.field_account_recurring_template__state
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment__state
+#: model:ir.model.fields,field_description:om_recurring_payments.field_recurring_payment_line__state
+#, fuzzy
+msgid "Status"
+msgstr "Estado"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__account_recurring_template__journal_state__draft
+#, fuzzy
+msgid "Un Posted"
+msgstr "Un Publicado"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__account_recurring_template__recurring_period__weeks
+#, fuzzy
+msgid "Weeks"
+msgstr "Semanas"
+
+#. module: om_recurring_payments
+#: model:ir.model.fields.selection,name:om_recurring_payments.selection__account_recurring_template__recurring_period__years
+#, fuzzy
+msgid "Years"
+msgstr "Años"
+
+#. module: om_recurring_payments
+#. odoo-python
+#: code:addons/om_recurring_payments/models/recurring_payment.py:0
+#, fuzzy, python-format
+msgid "You cannot Set to Draft as one of the line is already in done state"
+msgstr "No se puede establecer en borrador porque una de las líneas ya está en estado terminado"

--- a/task_check_list/i18n/es_CR.po
+++ b/task_check_list/i18n/es_CR.po
@@ -1,0 +1,126 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* task_check_list
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0-20230613\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-08 21:11+0000\n"
+"PO-Revision-Date: 2023-07-08 15:11-0600\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es_CR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_project_task__task_checklist
+#, fuzzy
+msgid "Check List"
+msgstr "Lista de verificación"
+
+#. module: task_check_list
+#: model_terms:ir.ui.view,arch_db:task_check_list.view_task_form2_inherit_form_view
+#, fuzzy
+msgid "Checklist"
+msgstr "Lista de verificación"
+
+#. module: task_check_list
+#: model:ir.model,name:task_check_list.model_task_checklist
+#, fuzzy
+msgid "Checklist for the task"
+msgstr "Lista de comprobación para la tarea"
+
+#. module: task_check_list
+#: model_terms:ir.actions.act_window,help:task_check_list.action_task_checklist
+#, fuzzy
+msgid "Click to create New Checklist"
+msgstr "Haga clic para crear una nueva lista de verificación"
+
+#. module: task_check_list
+#: model_terms:ir.ui.view,arch_db:task_check_list.view_task_form2_inherit_form_view
+#, fuzzy
+msgid "Completed"
+msgstr "Terminado"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_task_checklist__create_uid
+#, fuzzy
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_task_checklist__create_date
+#, fuzzy
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_task_checklist__description
+#, fuzzy
+msgid "Description"
+msgstr "Descripción"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_task_checklist__display_name
+#, fuzzy
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_task_checklist__id
+#, fuzzy
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_task_checklist____last_update
+#, fuzzy
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_task_checklist__write_uid
+#, fuzzy
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_task_checklist__write_date
+#, fuzzy
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_project_task__max_rate
+#, fuzzy
+msgid "Maximum rate"
+msgstr "Tipo máximo"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_task_checklist__name
+#, fuzzy
+msgid "Name"
+msgstr "Nombre"
+
+#. module: task_check_list
+#: model:ir.model.fields,field_description:task_check_list.field_project_task__checklist_progress
+#, fuzzy
+msgid "Progress"
+msgstr "Progreso"
+
+#. module: task_check_list
+#: model:ir.model,name:task_check_list.model_project_task
+msgid "Task"
+msgstr "Tarea"
+
+#. module: task_check_list
+#: model:ir.actions.act_window,name:task_check_list.action_task_checklist
+#: model:ir.ui.menu,name:task_check_list.task_check_list_menu
+#, fuzzy
+msgid "Task Checklist"
+msgstr "Lista de comprobación de tareas"


### PR DESCRIPTION
This PR focuses on improving the Internationalization (I18N) aspect of the project by updating the translation terms in the es_CR locale. The changes aim to enhance the user experience for Spanish-speaking users in Costa Rica by ensuring consistency, accuracy, and adherence to style guidelines. The updates provide a more polished and localized experience, making the application more accessible and tailored to the specific needs of this user group. Feedback and contributions are welcomed to achieve a seamless and inclusive user experience for a global audience.