### PR TITLE
[16.0] [FIX] hr.payslip.employees wizard

### DIFF
--- a/om_hr_payroll/wizard/hr_payroll_payslips_by_employees_views.xml
+++ b/om_hr_payroll/wizard/hr_payroll_payslips_by_employees_views.xml
@@ -6,20 +6,20 @@
         <field name="model">hr.payslip.employees</field>
         <field name="arch" type="xml">
             <form string="Payslips by Employees">
-                <header>
-                    <button icon="fa-cogs" string="Generate" name="compute_sheet" type="object" class="oe_highlight"/>
-                </header>
-                <group>
-                    <span colspan="4" nolabel="1">This wizard will generate payslips for all selected employee(s) based
-                        on the dates and credit note specified on Payslips Run.
-                    </span>
-                </group>
-                <group colspan="4">
-                    <separator string="Employees" colspan="4"/>
-                    <newline/>
-                    <field name="employee_ids" nolabel="1"/>
-                </group>
-            </form>
+                    <header>
+                        <button icon="fa-cogs" string="Generate" name="compute_sheet" type="object" class="oe_highlight"/>
+                    </header>
+                    <sheet>
+                        <div class="alert alert-info mb-0" role="alert">
+                            This wizard will generate payslips for all selected employee(s) based on the dates and credit note specified on Payslips Run.
+                        </div>
+                        <notebook>
+                            <page name="employees" string="Employees">
+                                <field name="employee_ids"/>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>
         </field>
     </record>
 


### PR DESCRIPTION
## Summary:
This commit fixes a problem with the "hr.payslip.employees" wizard, because the columns are not displayed correctly

## Before this commit:
![image](https://github.com/odoomates/odooapps/assets/95722875/e532cdb2-b7bc-495c-aed6-4a447902e8f2)

## After this commit:
![Captura desde 2023-07-29 21-00-39](https://github.com/odoomates/odooapps/assets/95722875/fe386ab3-7db7-4304-b8c0-28f401968567)

