### PR TITLE
[FIX] om_hr_payroll: warning in log unknown directive

### DIFF
--- a/om_hr_payroll/__manifest__.py
+++ b/om_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Odoo 16 HR Payroll',
     'category': 'Generic Modules/Human Resources',
-    'version': '16.0.1.0.1',
+    'version': '16.0.1.0.2',
     'sequence': 1,
     'author': 'Odoo Mates, Odoo SA',
     'summary': 'Payroll For Odoo 16 Community Edition',

--- a/om_hr_payroll/views/report_contribution_register_templates.xml
+++ b/om_hr_payroll/views/report_contribution_register_templates.xml
@@ -49,11 +49,11 @@
                                     </td>
                                     <td class="text-end">
                                         <span t-esc="line.amount"
-                                              t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
+                                              t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
                                     </td>
                                     <td class="text-end">
                                         <span t-esc="line.total"
-                                              t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
+                                              t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
                                     </td>
                                 </tr>
                             </tbody>
@@ -68,7 +68,7 @@
                                         </td>
                                         <td class="text-end">
                                             <span t-esc="lines_total.get(o.id)"
-                                                  t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
+                                                  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
                                         </td>
                                     </tr>
                                 </table>

--- a/om_hr_payroll/views/report_payslip_details_templates.xml
+++ b/om_hr_payroll/views/report_payslip_details_templates.xml
@@ -97,7 +97,7 @@
                                     </td>
                                     <td class="text-end">
                                         <span t-esc="h['total']"
-                                              t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
+                                              t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
                                     </td>
                                 </tr>
                             </tbody>
@@ -130,7 +130,7 @@
                                     </td>
                                     <td class="text-end">
                                         <span t-esc="p.get('total', 0)"
-                                              t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
+                                              t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
                                     </td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
before this commit, on printing various reports, in the log it is shows a warning as follows:

Unknown directives or unused attributes

after this commit, no warning will be shown in the log on printing the report