### PR TITLE
[I18N][FIX] Update translation terms in es_CR (unexpected characters)

### DIFF
--- a/om_hr_payroll/i18n/es_CR.po
+++ b/om_hr_payroll/i18n/es_CR.po
@@ -63,13 +63,13 @@ msgstr "%s (copia)"
 #: model:ir.actions.report,print_report_name:om_hr_payroll.action_report_payslip
 #, fuzzy
 msgid "('Payslip - %s' % (object.employee_id.name))"
-msgstr "(«Nómina - %s» % (object.employee_id.nombre))"
+msgstr "('Nómina - %s' % (object.employee_id.nombre))"
 
 #. module: om_hr_payroll
 #: model:ir.actions.report,print_report_name:om_hr_payroll.payslip_details_report
 #, fuzzy
 msgid "('Payslip Details - %s' % (object.employee_id.name))"
-msgstr "(«Datos de la nómina - %s» % (object.employee_id.nombre))"
+msgstr "('Datos de la nómina - %s' % (object.employee_id.nombre))"
 
 #. module: om_hr_payroll
 #: model:ir.model.fields,help:om_hr_payroll.field_hr_payslip__state

--- a/om_hr_payroll/wizard/hr_payroll_payslips_by_employees_views.xml
+++ b/om_hr_payroll/wizard/hr_payroll_payslips_by_employees_views.xml
@@ -6,20 +6,20 @@
         <field name="model">hr.payslip.employees</field>
         <field name="arch" type="xml">
             <form string="Payslips by Employees">
-                <header>
-                    <button icon="fa-cogs" string="Generate" name="compute_sheet" type="object" class="oe_highlight"/>
-                </header>
-                <group>
-                    <span colspan="4" nolabel="1">This wizard will generate payslips for all selected employee(s) based
-                        on the dates and credit note specified on Payslips Run.
-                    </span>
-                </group>
-                <group colspan="4">
-                    <separator string="Employees" colspan="4"/>
-                    <newline/>
-                    <field name="employee_ids" nolabel="1"/>
-                </group>
-            </form>
+                    <header>
+                        <button icon="fa-cogs" string="Generate" name="compute_sheet" type="object" class="oe_highlight"/>
+                    </header>
+                    <sheet>
+                        <div class="alert alert-info mb-0" role="alert">
+                            This wizard will generate payslips for all selected employee(s) based on the dates and credit note specified on Payslips Run.
+                        </div>
+                        <notebook>
+                            <page name="employees" string="Employees">
+                                <field name="employee_ids"/>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>
         </field>
     </record>
 


### PR DESCRIPTION
This PR is responsible for correcting two incorrect characters when performing the translation (#105), these generate an exception when trying to print a PDF through the action "om_hr_payroll.action_report_payslip"