### PR TITLE
[FIX]hr_payroll_account: Incorrect user error due to line variable

### DIFF
--- a/om_hr_payroll_account/models/hr_payroll_account.py
+++ b/om_hr_payroll_account/models/hr_payroll_account.py
@@ -71,7 +71,7 @@ class HrPayslip(models.Model):
                 'journal_id': slip.journal_id.id,
                 'date': date,
             }
-            if not any(line.salary_rule_id.account_debit and line.salary_rule_id.account_credit for line in slip.details_by_salary_rule_category):
+            if not any(slip.line_ids.salary_rule_id.account_debit and slip.line_ids.salary_rule_id.account_credit for line in slip.details_by_salary_rule_category):
                 raise UserError(_('Missing Debit Or Credit Account in Salary Rule'))
             for line in slip.details_by_salary_rule_category:
                 amount = currency.round(slip.credit_note and -line.total or line.total)


### PR DESCRIPTION
not initialized

It looks like this code was copied from a few lines below where the line variable was initialised through the for loop. This suggestion works but the original code may be better because the code no longer checks if all lines have valid debit and credit accounts.