### PR TITLE
[FIX] Analytic Distribution in journal entry report

### DIFF
--- a/accounting_pdf_reports/models/account_move_line.py
+++ b/accounting_pdf_reports/models/account_move_line.py
@@ -75,3 +75,32 @@ class AccountMoveLine(models.Model):
             where_string, where_params = query.where_clause
             tables, where_clause, where_clause_params = from_string, where_string, from_params + where_params
         return tables, where_clause, where_clause_params
+
+    def format_analytic_distribution(self, distribution):
+        """
+        Format analytic distribution entries, handling both single and compound keys.
+
+        Args:
+            self: Odoo environment
+            distribution: Dict of analytic distribution (e.g. {'2':90} or {'2,1':90, '3':10})
+
+        Returns:
+            List of formatted strings with analytic account info and percentages
+        """
+        if not distribution:
+            return []
+        result = []
+        for key, percentage in distribution.items():
+            account_ids = [int(x) for x in key.split(',')]
+            accounts_info = []
+
+            for account_id in account_ids:
+                account = self.env['account.analytic.account'].browse(account_id)[0]
+                if account.partner_id:
+                    accounts_info.append(f"{account.name} - {account.partner_id.name}")
+                else:
+                    accounts_info.append(account.name)
+
+            formatted_entry = f"{', '.join(accounts_info)}: {percentage}%"
+            result.append(formatted_entry)
+        return result

--- a/accounting_pdf_reports/report/report_journal_entries.xml
+++ b/accounting_pdf_reports/report/report_journal_entries.xml
@@ -45,7 +45,7 @@
                                         <th>Date</th>
                                         <th>Partner</th>
                                         <th>Label</th>
-                                        <th>Analytic Account</th>
+                                        <th>Analytic Distribution</th>
                                         <th>Debit</th>
                                         <th>Credit</th>
                                     </tr>
@@ -68,7 +68,10 @@
                                                 <span t-field="line.name"/>
                                             </td>
                                             <td>
-                                                <span t-field="line.analytic_account_id.display_name"/>
+                                                <div t-foreach="line.format_analytic_distribution(line.analytic_distribution)" t-as="entry">
+                                                    <t t-esc="entry"/>
+                                                    <br/>
+                                                </div>
                                             </td>
                                             <td class="text-end">
                                                 <span t-field="line.debit"


### PR DESCRIPTION
#### fix error when printing Journal Entry
```odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
AttributeError: 'account.move.line' object has no attribute 'analytic_account_id'
Template: accounting_pdf_reports.report_journal_entries
Path: /t/t/t/t/div/div[3]/table/tbody/t[3]/tr/td[5]/span
Node: <span t-field="line.analytic_account_id.display_name"/>```
