### PR TITLE
[Fix] Failing unit test for HR payroll module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ __pycache__/
 # C extensions
 *.so
 
-
-
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
@@ -60,6 +58,3 @@ dmypy.json
 # Miscellaneous
 var/
 .DS_Store
-legacy
-openeducat_erp
-pyrightconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,65 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+node_modules
+
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# IDE
+.vscode/
+.idea/
+
+# Miscellaneous
+var/
+.DS_Store
+legacy
+openeducat_erp
+pyrightconfig.json

--- a/om_hr_payroll/tests/test_payslip_flow.py
+++ b/om_hr_payroll/tests/test_payslip_flow.py
@@ -4,7 +4,7 @@
 import os
 
 from odoo.tools import config, test_reports
-from odoo.addons.om_om_hr_payroll.tests.common import TestPayslipBase
+from .common import TestPayslipBase
 
 
 class TestPayslipFlow(TestPayslipBase):


### PR DESCRIPTION
Odoo tests were failing because importing the `common` test module in the HR payroll test suite was failing.
Switching to a relative import fixes the issue