### PR TITLE
[FIX] om_account_followup: defer translation for email_subject default

### DIFF
--- a/om_account_followup/wizard/followup_print.py
+++ b/om_account_followup/wizard/followup_print.py
@@ -31,7 +31,7 @@ class FollowupPrint(models.TransientModel):
                                  related='followup_id.company_id')
     email_conf = fields.Boolean('Send Email Confirmation')
     email_subject = fields.Char('Email Subject', size=64,
-                                default=_('Invoices Reminder'))
+                                default=lambda self: _('Invoices Reminder'))
     partner_lang = fields.Boolean(
         'Send Email in Partner Language', default=True,
         help='Do not change message text, if you want to send email in '


### PR DESCRIPTION
The email_subject field is defined with `default=_('Invoices Reminder')`, which evaluates the translation at module load time. This triggers warnings about missing translation language and prevents proper translation at runtime.

Using `default=lambda self: _('Invoices Reminder')` defers evaluation until record creation, ensuring correct translation in the user’s language and removing the warning.

For reference, the warning looks like this:
```
WARNING innovara odoo.tools.translate: no translation language detected, skipping translation <frame at 0x7758ce5943c0, file '.../custom-addons/odoomates/om_account_followup/wizard/followup_print.py', line 34, code FollowupPrint> 
[...]
File ".../custom-addons/odoomates/om_account_followup/wizard/followup_print.py", line 34, in FollowupPrint
 default=_('Invoices Reminder'))
File ".../odoo/odoo/tools/translate.py", line 621, in get_text_alias
  module, lang = _get_translation_source(1)
File ".../odoo/tools/translate.py", line 610, in _get_translation_source
  lang = lang or _get_lang(frame, default_lang)
File ".../odoo/tools/translate.py", line 601, in _get_lang
  _logger.log(log_level, 'no translation language detected, skipping translation %s', frame, stack_info=True)
```