### PR TITLE
[FIX] om_account_asset : Fix xpath expression for asset category field

### DIFF
--- a/om_account_asset/views/account_move_views.xml
+++ b/om_account_asset/views/account_move_views.xml
@@ -11,7 +11,7 @@
                        force_save="1" column_invisible="parent.move_type != 'in_invoice'"
                        domain="[('type','=','purchase')]" context="{'default_type':'purchase'}"/>
             </xpath>
-            <xpath expr="//field[@name='journal_line_ids']/list/field[@name='account_id']" position="before">
+            <xpath expr="//field[@name='line_ids']/list/field[@name='account_id']" position="before">
                 <field string="Asset Category" name="asset_category_id"
                        column_invisible="1"/>
             </xpath>


### PR DESCRIPTION
In the commit 'b26818d' odoo repository , they reverted back to line_ids by removing journal_line_ids which end up causing the issue xpression path not found.