### PR TITLE
Fix translation error on loading om_account_followup

### DIFF
--- a/om_account_followup/wizard/followup_print.py
+++ b/om_account_followup/wizard/followup_print.py
@@ -31,7 +31,7 @@ class FollowupPrint(models.TransientModel):
                                  related='followup_id.company_id')
     email_conf = fields.Boolean('Send Email Confirmation')
     email_subject = fields.Char('Email Subject', size=64,
-                                default=_('Invoices Reminder'))
+                                default=lambda: _('Invoices Reminder'))
     partner_lang = fields.Boolean(
         'Send Email in Partner Language', default=True,
         help='Do not change message text, if you want to send email in '


### PR DESCRIPTION
I was getting this error:
```
odoo-1   | 2025-12-10 22:45:58,334 16 WARNING fmwp odoo.tools.translate: no translation language detected, skipping translation <frame at 0x7f3e5102d7e0, file '/odoo/addons/om_account_followup/wizard/followup_print.py', line 34, code FollowupPrint> 
odoo-1   | Stack (most recent call last):
odoo-1   |   File "/odoo/.venv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/threading.py", line 1015, in _bootstrap
odoo-1   |     self._bootstrap_inner()
odoo-1   |   File "/odoo/.venv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/threading.py", line 1044, in _bootstrap_inner
odoo-1   |     self.run()
odoo-1   |   File "/odoo/.venv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/threading.py", line 995, in run
odoo-1   |     self._target(*self._args, **self._kwargs)
odoo-1   |   File "/odoo/odoo/odoo/service/server.py", line 1165, in _runloop
odoo-1   |     self.process_work()
odoo-1   |   File "/odoo/odoo/odoo/service/server.py", line 1264, in process_work
odoo-1   |     base.models.ir_cron.ir_cron._process_jobs(db_name)
odoo-1   |   File "/odoo/odoo/odoo/addons/base/models/ir_cron.py", line 151, in _process_jobs
odoo-1   |     registry = Registry(db_name).check_signaling()
odoo-1   |   File "/odoo/odoo/odoo/modules/registry.py", line 108, in __new__
odoo-1   |     return cls.new(db_name)
odoo-1   |   File "/odoo/.venv/lib/python3.13/site-packages/decorator.py", line 232, in fun
odoo-1   |     return caller(func, *(extras + args), **kw)
odoo-1   |   File "/odoo/odoo/odoo/tools/func.py", line 97, in locked
odoo-1   |     return func(inst, *args, **kwargs)
odoo-1   |   File "/odoo/odoo/odoo/modules/registry.py", line 129, in new
odoo-1   |     odoo.modules.load_modules(registry, force_demo, status, update_module)
odoo-1   |   File "/odoo/odoo/odoo/modules/loading.py", line 485, in load_modules
odoo-1   |     processed_modules += load_marked_modules(env, graph,
odoo-1   |   File "/odoo/odoo/odoo/modules/loading.py", line 365, in load_marked_modules
odoo-1   |     loaded, processed = load_module_graph(
odoo-1   |   File "/odoo/odoo/odoo/modules/loading.py", line 186, in load_module_graph
odoo-1   |     load_openerp_module(package.name)
odoo-1   |   File "/odoo/odoo/odoo/modules/module.py", line 384, in load_openerp_module
odoo-1   |     __import__(qualname)
odoo-1   |   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
odoo-1   |   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
odoo-1   |   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
odoo-1   |   File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
odoo-1   |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
odoo-1   |   File "/odoo/addons/om_account_followup/__init__.py", line 1, in <module>
odoo-1   |     from . import wizard
odoo-1   |   File "<frozen importlib._bootstrap>", line 1415, in _handle_fromlist
odoo-1   |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
odoo-1   |   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
odoo-1   |   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
odoo-1   |   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
odoo-1   |   File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
odoo-1   |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
odoo-1   |   File "/odoo/addons/om_account_followup/wizard/__init__.py", line 1, in <module>
odoo-1   |     from . import followup_print
odoo-1   |   File "<frozen importlib._bootstrap>", line 1415, in _handle_fromlist
odoo-1   |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
odoo-1   |   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
odoo-1   |   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
odoo-1   |   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
odoo-1   |   File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
odoo-1   |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
odoo-1   |   File "/odoo/addons/om_account_followup/wizard/followup_print.py", line 7, in <module>
odoo-1   |     class FollowupPrint(models.TransientModel):
odoo-1   |   File "/odoo/addons/om_account_followup/wizard/followup_print.py", line 34, in FollowupPrint
odoo-1   |     default=_('Invoices Reminder'))
odoo-1   |   File "/odoo/odoo/odoo/tools/translate.py", line 621, in get_text_alias
odoo-1   |     module, lang = _get_translation_source(1)
odoo-1   |   File "/odoo/odoo/odoo/tools/translate.py", line 610, in _get_translation_source
odoo-1   |     lang = lang or _get_lang(frame, default_lang)
odoo-1   |   File "/odoo/odoo/odoo/tools/translate.py", line 601, in _get_lang
odoo-1   |     _logger.log(log_level, 'no translation language detected, skipping translation %s', frame, stack_info=True)

```