### PR TITLE
fix(om_account_budget): replace _where_calc/_apply_ir_rules with read…

### DIFF
--- a/om_account_budget/models/account_budget.py
+++ b/om_account_budget/models/account_budget.py
@@ -172,13 +172,8 @@ class CrossoveredBudgetLines(models.Model):
                 if acc_ids:
                     domain += [('general_account_id', 'in', acc_ids)]
 
-                where_query = analytic_line_obj._where_calc(domain)
-                analytic_line_obj._apply_ir_rules(where_query, 'read')
-                from_string, from_params = where_query.from_clause
-                where_string, where_params = where_query.where_clause
-                from_clause, where_clause, where_clause_params = from_string, where_string, from_params + where_params
-
-                select = "SELECT SUM(amount) from " + from_clause + " where " + where_clause
+                result = analytic_line_obj.read_group(domain, ['amount:sum'], [])
+                line.practical_amount = result[0]['amount'] if result and result[0]['amount'] is not None else 0.0
 
             else:
                 aml_obj = self.env['account.move.line']
@@ -187,16 +182,14 @@ class CrossoveredBudgetLines(models.Model):
                           ('date', '>=', date_from),
                           ('date', '<=', date_to)
                           ]
-                where_query = aml_obj._where_calc(domain)
-                aml_obj._apply_ir_rules(where_query, 'read')
-                from_string, from_params = where_query.from_clause
-                where_string, where_params = where_query.where_clause
-                from_clause, where_clause, where_clause_params = from_string, where_string, from_params + where_params
 
-                select = "SELECT sum(credit)-sum(debit) from " + from_clause + " where " + where_clause
-
-            self.env.cr.execute(select, where_clause_params)
-            line.practical_amount = self.env.cr.fetchone()[0] or 0.0
+                result = aml_obj.read_group(domain, ['credit:sum', 'debit:sum'], [])
+                if result:
+                    credit = result[0].get('credit') or 0.0
+                    debit = result[0].get('debit') or 0.0
+                    line.practical_amount = credit - debit
+                else:
+                    line.practical_amount = 0.0
 
     def _compute_theoritical_amount(self):
         # beware: 'today' variable is mocked in the python tests and thus, its implementation matter


### PR DESCRIPTION
Summary
Replaces the deprecated _where_calc() and _apply_ir_rules() raw SQL pattern in _compute_practical_amount with the ORM read_group() API, fixing compatibility with Odoo 19.

Changes
account.analytic.line amount query now uses read_group(domain, ['amount:sum'], [])
account.move.line credit/debit query now uses read_group(domain, ['credit:sum', 'debit:sum'], [])
Removed manual raw SQL execution via env.cr.execute()

Why
_where_calc() and _apply_ir_rules() were removed in Odoo 17+ and cause errors in Odoo 19. The read_group() replacement is the idiomatic ORM approach and handles security rules automatically.
