### PR TITLE
[18.0] Fix om_fiscal_year duplicate Hard Lock Date labels + journal xpath

### DIFF
--- a/om_account_accountant/views/account_journal.xml
+++ b/om_account_accountant/views/account_journal.xml
@@ -6,10 +6,12 @@
         <field name="model">account.journal</field>
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='inbound_payment_method_line_ids']/list/field[@name='payment_account_id']" position="attributes">
+            <!-- Use descendant //field so the xpath still matches when
+                 account_payment (or other modules) wrap/alter the <list>. -->
+            <xpath expr="//field[@name='inbound_payment_method_line_ids']//field[@name='payment_account_id']" position="attributes">
                 <attribute name="optional">show</attribute>
             </xpath>
-            <xpath expr="//field[@name='outbound_payment_method_line_ids']/list/field[@name='payment_account_id']" position="attributes">
+            <xpath expr="//field[@name='outbound_payment_method_line_ids']//field[@name='payment_account_id']" position="attributes">
                 <attribute name="optional">show</attribute>
             </xpath>
         </field>

--- a/om_fiscal_year/models/account_settings.py
+++ b/om_fiscal_year/models/account_settings.py
@@ -1,30 +1,41 @@
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ResConfigSettings(models.TransientModel):
-    _inherit = 'res.config.settings'
+    _inherit = "res.config.settings"
 
     fiscalyear_last_day = fields.Integer(
-        related='company_id.fiscalyear_last_day', readonly=False
+        related="company_id.fiscalyear_last_day", readonly=False
     )
     fiscalyear_last_month = fields.Selection(
-        related='company_id.fiscalyear_last_month', readonly=False
+        related="company_id.fiscalyear_last_month", readonly=False
     )
+    # Explicit strings required: related fields inherit the comodel field label
+    # (Hard Lock Date) otherwise, which trips Odoo's duplicate-label warning and
+    # floods Sentry when sentry_logging_level includes warnings.
     tax_lock_date = fields.Date(
-        related='company_id.hard_lock_date', readonly=False
+        string="Tax Return Lock Date",
+        related="company_id.hard_lock_date",
+        readonly=False,
     )
     sale_lock_date = fields.Date(
-        related='company_id.hard_lock_date', readonly=False
+        string="Sales Lock Date",
+        related="company_id.hard_lock_date",
+        readonly=False,
     )
     purchase_lock_date = fields.Date(
-        related='company_id.hard_lock_date', readonly=False
+        string="Purchase Lock Date",
+        related="company_id.hard_lock_date",
+        readonly=False,
     )
     hard_lock_date = fields.Date(
-        related='company_id.hard_lock_date', readonly=False
+        string="Hard Lock Date",
+        related="company_id.hard_lock_date",
+        readonly=False,
     )
     fiscalyear_lock_date = fields.Date(
-        related='company_id.fiscalyear_lock_date', readonly=False
+        related="company_id.fiscalyear_lock_date", readonly=False
     )
     group_fiscal_year = fields.Boolean(
-        string='Fiscal Years', implied_group='om_fiscal_year.group_fiscal_year'
+        string="Fiscal Years", implied_group="om_fiscal_year.group_fiscal_year"
     )


### PR DESCRIPTION
## Summary

Two Community accounting issues observed on Odoo 18 production (Elementure):

1. **`om_fiscal_year`** — `tax_lock_date` / `sale_lock_date` / `purchase_lock_date` / `hard_lock_date` on `res.config.settings` are all `related='company_id.hard_lock_date'` **without** explicit `string=`. Related fields inherit the comodel label, so Odoo warns that multiple fields share **"Hard Lock Date"** (and Sentry captures it when logging includes warnings).
2. **`om_account_accountant`** — journal form xpath `//field[@name='inbound_payment_method_line_ids']/list/field[@name='payment_account_id']` failed during view combine (`ValueError: Element ... cannot be located in parent view`) when the payment-method list structure differs (e.g. with `account_payment` inheritance). Using descendant `//field[@name='payment_account_id']` is more resilient and matches patterns already used in Odoo core `account_payment` views.

## Changes

- `om_fiscal_year/models/account_settings.py`: set explicit `string=` on each lock-date related field.
- `om_account_accountant/views/account_journal.xml`: change xpath to `//field[@name='…_payment_method_line_ids']//field[@name='payment_account_id']`.

## Test plan

- [ ] Install/upgrade `om_fiscal_year` on Odoo 18; confirm no `Two fields … have the same label: Hard Lock Date` warning in logs.
- [ ] Open Accounting → Configuration → Journals form with `account_payment` installed; confirm no view inheritance error and payment account columns still optional=show.
- [ ] Smoke: Settings → Fiscal Years / lock dates UI still shows distinct labels.


Made with [Cursor](https://cursor.com)